### PR TITLE
Fixed buffer overflow on fmtprintf.c

### DIFF
--- a/compiler/crt/posixc/vfwprintf.c
+++ b/compiler/crt/posixc/vfwprintf.c
@@ -11,7 +11,7 @@
 #include "__fdesc.h"
 #include "__stdio.h"
 
-static int __putc(int c, void *fh);
+static int __putwc(wchar_t wc, void *fh);
 /*****************************************************************************
 
     NAME */
@@ -56,17 +56,17 @@ static int __putc(int c, void *fh);
         return 0;
     }
 
-    return __wvcformat ((void *)BADDR(fdesc->fcb->handle), __putc, format, args);
+    return __wvcformat ((void *)BADDR(fdesc->fcb->handle), __putwc, format, args);
 } /* vfwprintf */
 
-static int __putc(int c, void *fhp)
+static int __putwc(wchar_t wc, void *fhp)
 {
     BPTR fh = MKBADDR(fhp);
-    if (FWrite(fh, &c, 1, sizeof(wchar_t)) == WEOF)
+    if (FWrite(fh, &wc, 1, sizeof(wchar_t)) == WEOF)
     {
         errno = __stdc_ioerr2errno(IoErr());
         return WEOF;
     }
 
-    return c;
+    return wc;
 }

--- a/compiler/fmtprintf/fmtprintf.c
+++ b/compiler/fmtprintf/fmtprintf.c
@@ -250,7 +250,13 @@
                     wptr = va_arg(args, wchar_t *);
                     if (!wptr)
                         wptr = L"(null)";
-                    size2 = FMTPRINTF_WCSLEN(wptr);
+                    size_t req_bytes = FMTPRINTF_WCSLEN(wptr) * sizeof(wchar_t) + 1;
+                    char *temp_buffer = alloca(req_bytes);
+                    size2 = wcstombs(temp_buffer, wptr, req_bytes);
+                    if (size2 == (size_t)-1) {
+                        temp_buffer = "(invalid wide string)";
+                        size2 = FMTPRINTF_STRLEN(temp_buffer);
+                    }
 #else
                     buffer2 = va_arg(args, char *);
                     if (!buffer2)
@@ -259,7 +265,7 @@
 #endif
                     size2 = size2 <= preci ? size2 : preci;
 #ifdef IS_WIDE
-                    wcstombs(buffer2, wptr, size2);
+                    buffer2 = temp_buffer;
 #endif
                     preci = 0;
                     break;


### PR DESCRIPTION
- Fixed buffer overflow on fmtprintf.c
- Made vfwprintf wputc function more consistent passing wchar_t instead of int