### PR TITLE
Leaved out icons should not be renamed

### DIFF
--- a/workbench/system/Wanderer/wanderer.c
+++ b/workbench/system/Wanderer/wanderer.c
@@ -3078,6 +3078,7 @@ VOID Wanderer__Func_UpdateMenuStates(Object *WindowObj, Object *IconlistObj)
                 iconmenustate &= ~MENF_ICON_DELETE;
                 iconmenustate &= ~MENF_ICON_FORMAT;
                 iconmenustate &= ~MENF_ICON_EMPTYTRASH;
+                iconmenustate &= ~MENF_ICON_RENAME;
             }
             if (!(isRoot) && ((icon_entry->type == ST_USERDIR) || (icon_entry->type == ST_FILE)))
             {


### PR DESCRIPTION
The menu won't show the "Rename" option when the icon is a Leave out icon.