### PR TITLE
Leaved out icons are not renamed by RAmiga+R

### DIFF
--- a/workbench/system/Wanderer/wanderer.c
+++ b/workbench/system/Wanderer/wanderer.c
@@ -1874,7 +1874,7 @@ void wanderer_menufunc_icon_rename(void)
 
                 UnLock(lock);
             }
-            else
+            else if ((entry->type != ST_LINKDIR) && (entry->type != ST_LINKFILE))
             {
                 BOOL isInfoFile = FALSE;
                 STRPTR filename = entry->ile_IconEntry->ie_IconNode.ln_Name;


### PR DESCRIPTION
Leaved out icons are not renamed by RAmiga+R