### PR TITLE
crosstools: GCC 16.1.0 AROS cross-compiler port (targeting exp-gcc-16)

### DIFF
--- a/tools/crosstools/gnu/gcc-16.1.0-aros.diff
+++ b/tools/crosstools/gnu/gcc-16.1.0-aros.diff
@@ -1,9 +1,9 @@
-diff -ruN gcc-15.2.0/configure gcc-15.2.0.aros/configure
---- gcc-15.2.0/configure	2025-08-08 06:51:39.874338130 +0000
-+++ gcc-15.2.0.aros/configure	2020-12-27 16:58:14.310000000 +0000
-@@ -4099,6 +4099,9 @@
-   powerpcle-*-solaris*)
-     noconfigdirs="$noconfigdirs gdb sim tcl tk itcl"
+diff -ruN gcc-16.1.0/configure gcc-16.1.0.aros/configure
+--- gcc-16.1.0/configure	2026-04-30 08:33:19.000000000 +0000
++++ gcc-16.1.0.aros/configure	2020-12-27 16:58:14.310000000 +0000
+@@ -4174,6 +4174,9 @@
+     # always build newlib.
+     skipdirs=`echo " ${skipdirs} " | sed -e 's/ target-newlib / /'`
      ;;
 +  *-*-aros*)
 +    noconfigdirs="$noconfigdirs patch diff make tk tcl expect dejagnu autoconf automake texinfo bison send-pr gprof rcs guile perl itcl tix gnuserv gdb"
@@ -11,7 +11,7 @@ diff -ruN gcc-15.2.0/configure gcc-15.2.0.aros/configure
    powerpc-*-beos*)
      noconfigdirs="$noconfigdirs gdb"
      ;;
-@@ -4236,6 +4239,8 @@
+@@ -4311,6 +4314,8 @@
    rs6000-*-aix*)
      host_makefile_frag="config/mh-ppc-aix"
      ;;
@@ -20,12 +20,12 @@ diff -ruN gcc-15.2.0/configure gcc-15.2.0.aros/configure
  esac
  fi
  
-diff -ruN gcc-15.2.0/configure.ac gcc-15.2.0.aros/configure.ac
---- gcc-15.2.0/configure.ac	2025-08-08 06:51:39.874338130 +0000
-+++ gcc-15.2.0.aros/configure.ac	2020-12-27 16:58:14.310000000 +0000
-@@ -1316,6 +1316,9 @@
-   powerpcle-*-solaris*)
-     noconfigdirs="$noconfigdirs gdb sim tcl tk itcl"
+diff -ruN gcc-16.1.0/configure.ac gcc-16.1.0.aros/configure.ac
+--- gcc-16.1.0/configure.ac	2026-04-30 08:33:19.000000000 +0000
++++ gcc-16.1.0.aros/configure.ac	2020-12-27 16:58:14.310000000 +0000
+@@ -1328,6 +1328,9 @@
+     # always build newlib.
+     skipdirs=`echo " ${skipdirs} " | sed -e 's/ target-newlib / /'`
      ;;
 +  *-*-aros*)
 +    noconfigdirs="$noconfigdirs patch diff make tk tcl expect dejagnu autoconf automake texinfo bison send-pr gprof rcs guile perl itcl tix gnuserv gdb"
@@ -33,7 +33,7 @@ diff -ruN gcc-15.2.0/configure.ac gcc-15.2.0.aros/configure.ac
    powerpc-*-beos*)
      noconfigdirs="$noconfigdirs gdb"
      ;;
-@@ -1434,6 +1437,8 @@
+@@ -1446,6 +1449,8 @@
    rs6000-*-aix*)
      host_makefile_frag="config/mh-ppc-aix"
      ;;
@@ -42,9 +42,9 @@ diff -ruN gcc-15.2.0/configure.ac gcc-15.2.0.aros/configure.ac
  esac
  fi
  
-diff -ruN gcc-15.2.0/fixincludes/configure gcc-15.2.0.aros/fixincludes/configure
---- gcc-15.2.0/fixincludes/configure	2025-08-08 06:51:39.911209735 +0000
-+++ gcc-15.2.0.aros/fixincludes/configure	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/fixincludes/configure gcc-16.1.0.aros/fixincludes/configure
+--- gcc-16.1.0/fixincludes/configure	2026-04-30 08:33:19.000000000 +0000
++++ gcc-16.1.0.aros/fixincludes/configure	2020-12-27 16:58:14.310000000 +0000
 @@ -4817,6 +4817,7 @@
  fi
  else
@@ -53,9 +53,9 @@ diff -ruN gcc-15.2.0/fixincludes/configure gcc-15.2.0.aros/fixincludes/configure
  	i?86-*-msdosdjgpp* | \
  	i?86-*-mingw32* | \
  	x86_64-*-mingw32* | \
-diff -ruN gcc-15.2.0/fixincludes/configure.ac gcc-15.2.0.aros/fixincludes/configure.ac
---- gcc-15.2.0/fixincludes/configure.ac	2025-08-08 06:51:39.911209735 +0000
-+++ gcc-15.2.0.aros/fixincludes/configure.ac	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/fixincludes/configure.ac gcc-16.1.0.aros/fixincludes/configure.ac
+--- gcc-16.1.0/fixincludes/configure.ac	2026-04-30 08:33:19.000000000 +0000
++++ gcc-16.1.0.aros/fixincludes/configure.ac	2020-12-27 16:58:14.310000000 +0000
 @@ -49,6 +49,7 @@
  	TARGET=oneprocess
  fi],
@@ -64,15 +64,15 @@ diff -ruN gcc-15.2.0/fixincludes/configure.ac gcc-15.2.0.aros/fixincludes/config
  	i?86-*-msdosdjgpp* | \
  	i?86-*-mingw32* | \
  	x86_64-*-mingw32* | \
-diff -ruN gcc-15.2.0/fixincludes/fixincl.x gcc-15.2.0.aros/fixincludes/fixincl.x
---- gcc-15.2.0/fixincludes/fixincl.x	2025-08-08 06:52:54.954590595 +0000
-+++ gcc-15.2.0.aros/fixincludes/fixincl.x	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/fixincludes/fixincl.x gcc-16.1.0.aros/fixincludes/fixincl.x
+--- gcc-16.1.0/fixincludes/fixincl.x	2026-04-30 08:33:19.000000000 +0000
++++ gcc-16.1.0.aros/fixincludes/fixincl.x	2020-12-27 16:58:14.310000000 +0000
 @@ -15,7 +15,7 @@
   * certain ANSI-incompatible system header files which are fixed to work
   * correctly with ANSI C and placed in a directory that GNU C will search.
   *
-- * This file contains 274 fixup descriptions.
-+ * This file contains 275 fixup descriptions.
+- * This file contains 251 fixup descriptions.
++ * This file contains 252 fixup descriptions.
   *
   * See README for more information.
   *
@@ -115,16 +115,16 @@ diff -ruN gcc-15.2.0/fixincludes/fixincl.x gcc-15.2.0.aros/fixincludes/fixincl.x
   *  Description of Aab_Darwin7_9_Long_Double_Funcs fix
   */
  tSCC zAab_Darwin7_9_Long_Double_FuncsName[] =
-@@ -11204,7 +11236,7 @@
+@@ -10285,7 +10317,7 @@
   */
- #define REGEX_COUNT          318
+ #define REGEX_COUNT          291
  #define MACH_LIST_SIZE_LIMIT 187
--#define FIX_COUNT            274
-+#define FIX_COUNT            275
+-#define FIX_COUNT            251
++#define FIX_COUNT            252
  
  /*
   *  Enumerate the fixes
-@@ -11212,6 +11244,7 @@
+@@ -10293,6 +10325,7 @@
  typedef enum {
      AAB_AIX_STDIO_FIXIDX,
      AAB_AIX_FCNTL_FIXIDX,
@@ -132,7 +132,7 @@ diff -ruN gcc-15.2.0/fixincludes/fixincl.x gcc-15.2.0.aros/fixincludes/fixincl.x
      AAB_DARWIN7_9_LONG_DOUBLE_FUNCS_FIXIDX,
      DARWIN_API_AVAILABILITY_FIXIDX,
      AAB_FD_ZERO_ASM_POSIX_TYPES_H_FIXIDX,
-@@ -11497,6 +11530,11 @@
+@@ -10555,6 +10588,11 @@
       AAB_AIX_FCNTL_TEST_CT, FD_MACH_ONLY | FD_SUBROUTINE,
       aAab_Aix_FcntlTests,   apzAab_Aix_FcntlPatch, 0 },
  
@@ -144,9 +144,9 @@ diff -ruN gcc-15.2.0/fixincludes/fixincl.x gcc-15.2.0.aros/fixincludes/fixincl.x
    {  zAab_Darwin7_9_Long_Double_FuncsName,    zAab_Darwin7_9_Long_Double_FuncsList,
       apzAab_Darwin7_9_Long_Double_FuncsMachs,
       AAB_DARWIN7_9_LONG_DOUBLE_FUNCS_TEST_CT, FD_MACH_ONLY | FD_REPLACEMENT,
-diff -ruN gcc-15.2.0/fixincludes/inclhack.def gcc-15.2.0.aros/fixincludes/inclhack.def
---- gcc-15.2.0/fixincludes/inclhack.def	2025-08-08 06:51:39.912338764 +0000
-+++ gcc-15.2.0.aros/fixincludes/inclhack.def	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/fixincludes/inclhack.def gcc-16.1.0.aros/fixincludes/inclhack.def
+--- gcc-16.1.0/fixincludes/inclhack.def	2026-04-30 08:33:19.000000000 +0000
++++ gcc-16.1.0.aros/fixincludes/inclhack.def	2020-12-27 16:58:14.310000000 +0000
 @@ -103,6 +103,25 @@
  };
  
@@ -173,9 +173,9 @@ diff -ruN gcc-15.2.0/fixincludes/inclhack.def gcc-15.2.0.aros/fixincludes/inclha
   *  On Mac OS 10.3.9, the 'long double' functions are available in
   *  libSystem, but are not prototyped in math.h.
   */
-diff -ruN gcc-15.2.0/gcc/config/aarch64/aros.h gcc-15.2.0.aros/gcc/config/aarch64/aros.h
---- gcc-15.2.0/gcc/config/aarch64/aros.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/config/aarch64/aros.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/aarch64/aros.h gcc-16.1.0.aros/gcc/config/aarch64/aros.h
+--- gcc-16.1.0/gcc/config/aarch64/aros.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/aarch64/aros.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,63 @@
 +/* Configuration file for ARM AROS EABI targets.
 +   Copyright (C) 2004, 2005, 2006, 2007, 2010
@@ -240,9 +240,9 @@ diff -ruN gcc-15.2.0/gcc/config/aarch64/aros.h gcc-15.2.0.aros/gcc/config/aarch6
 +#undef LIBGCC_SPEC
 +#define LIBGCC_SPEC "-lgcc"
 +
-diff -ruN gcc-15.2.0/gcc/config/aarch64/t-aros gcc-15.2.0.aros/gcc/config/aarch64/t-aros
---- gcc-15.2.0/gcc/config/aarch64/t-aros	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/config/aarch64/t-aros	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/aarch64/t-aros gcc-16.1.0.aros/gcc/config/aarch64/t-aros
+--- gcc-16.1.0/gcc/config/aarch64/t-aros	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/aarch64/t-aros	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,21 @@
 +# Copyright (C) 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
 +# 2008, 2010 Free Software Foundation, Inc.
@@ -265,9 +265,9 @@ diff -ruN gcc-15.2.0/gcc/config/aarch64/t-aros gcc-15.2.0.aros/gcc/config/aarch6
 +
 +
 +
-diff -ruN gcc-15.2.0/gcc/config/arm/aros.h gcc-15.2.0.aros/gcc/config/arm/aros.h
---- gcc-15.2.0/gcc/config/arm/aros.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/config/arm/aros.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/arm/aros.h gcc-16.1.0.aros/gcc/config/arm/aros.h
+--- gcc-16.1.0/gcc/config/arm/aros.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/arm/aros.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,89 @@
 +/* Configuration file for ARM AROS EABI targets.
 +   Copyright (C) 2004, 2005, 2006, 2007, 2010
@@ -358,9 +358,9 @@ diff -ruN gcc-15.2.0/gcc/config/arm/aros.h gcc-15.2.0.aros/gcc/config/arm/aros.h
 +
 +/* FIXME: AROS doesn't support dw2 unwinding yet.  */
 +#undef MD_FALLBACK_FRAME_STATE_FOR
-diff -ruN gcc-15.2.0/gcc/config/arm/t-aros gcc-15.2.0.aros/gcc/config/arm/t-aros
---- gcc-15.2.0/gcc/config/arm/t-aros	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/config/arm/t-aros	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/arm/t-aros gcc-16.1.0.aros/gcc/config/arm/t-aros
+--- gcc-16.1.0/gcc/config/arm/t-aros	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/arm/t-aros	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,84 @@
 +# Copyright (C) 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
 +# 2008, 2010 Free Software Foundation, Inc.
@@ -446,9 +446,9 @@ diff -ruN gcc-15.2.0/gcc/config/arm/t-aros gcc-15.2.0.aros/gcc/config/arm/t-aros
 +MULTILIB_REUSE		+= marm/mlittle-endian/march.armv7-a+fp/mfpu.vfpv3-d16/mfloat-abi.hard=mlittle-endian/march.armv7-a+fp/mfloat-abi.hard
 +MULTILIB_REUSE		+= marm/mlittle-endian/march.armv7-a+fp/mfpu.vfpv3-d16/mfloat-abi.hard=mlittle-endian/march.armv7-a+fp/mfpu.vfpv3-d16/mfloat-abi.hard
 +MULTILIB_REUSE		+= marm/mlittle-endian/march.armv7-a+fp/mfpu.neon/mfloat-abi.hard=mlittle-endian/march.armv7-a+fp/mfpu.neon/mfloat-abi.hard
-diff -Naur gcc-15.2.0/gcc/config/aros.h gcc-15.2.0.aros/gcc/config/aros.h
---- gcc-15.2.0/gcc/config/aros.h	1970-01-01 01:00:00.000000000 +0100
-+++ gcc-15.2.0.aros/gcc/config/aros.h	2024-09-10 00:03:13.043815916 +0200
+diff -Naur gcc-16.1.0/gcc/config/aros.h gcc-16.1.0.aros/gcc/config/aros.h
+--- gcc-16.1.0/gcc/config/aros.h	1970-01-01 01:00:00.000000000 +0100
++++ gcc-16.1.0.aros/gcc/config/aros.h	2024-09-10 00:03:13.043815916 +0200
 @@ -0,0 +1,112 @@
 +/* Definitions for AROS
 +   Copyright (C) 1995, 1996, 1997, 1998, 1999, 2000 Free Software Foundation, Inc.
@@ -562,9 +562,9 @@ diff -Naur gcc-15.2.0/gcc/config/aros.h gcc-15.2.0.aros/gcc/config/aros.h
 +#define TARGET_HAS_F_SETLKW
 +
 +#define TARGET_POSIX_IO
-diff -ruN gcc-15.2.0/gcc/config/aros.opt gcc-15.2.0.aros/gcc/config/aros.opt
---- gcc-15.2.0/gcc/config/aros.opt	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/config/aros.opt	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/aros.opt gcc-16.1.0.aros/gcc/config/aros.opt
+--- gcc-16.1.0/gcc/config/aros.opt	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/aros.opt	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,41 @@
 +; Processor-independent options for AROS.
 +
@@ -607,14 +607,14 @@ diff -ruN gcc-15.2.0/gcc/config/aros.opt gcc-15.2.0.aros/gcc/config/aros.opt
 +nix
 +Driver
 +
-diff -ruN gcc-15.2.0/gcc/config/aros.opt.urls gcc-15.2.0.aros/gcc/config/aros.opt.urls
---- gcc-15.2.0/gcc/config/aros.opt.urls	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/config/aros.opt.urls	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/aros.opt.urls gcc-16.1.0.aros/gcc/config/aros.opt.urls
+--- gcc-16.1.0/gcc/config/aros.opt.urls	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/aros.opt.urls	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1 @@
 +; 
-diff -ruN gcc-15.2.0/gcc/config/aros-stdint.h gcc-15.2.0.aros/gcc/config/aros-stdint.h
---- gcc-15.2.0/gcc/config/aros-stdint.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/config/aros-stdint.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/aros-stdint.h gcc-16.1.0.aros/gcc/config/aros-stdint.h
+--- gcc-16.1.0/gcc/config/aros-stdint.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/aros-stdint.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,56 @@
 +/* Definitions for <stdint.h> types for AROS systems.
 +   Copyright (C) 2018 Free Software Foundation, Inc.
@@ -672,9 +672,9 @@ diff -ruN gcc-15.2.0/gcc/config/aros-stdint.h gcc-15.2.0.aros/gcc/config/aros-st
 +
 +#define INTPTR_TYPE       (LONG_TYPE_SIZE == 64 ?  INT64_TYPE :  INT32_TYPE)
 +#define UINTPTR_TYPE      (LONG_TYPE_SIZE == 64 ? UINT64_TYPE : UINT32_TYPE)
-diff -ruN gcc-15.2.0/gcc/config/i386/aros64.h gcc-15.2.0.aros/gcc/config/i386/aros64.h
---- gcc-15.2.0/gcc/config/i386/aros64.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/config/i386/aros64.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/i386/aros64.h gcc-16.1.0.aros/gcc/config/i386/aros64.h
+--- gcc-16.1.0/gcc/config/i386/aros64.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/i386/aros64.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,34 @@
 +/* Definitions for AMD x86_64 running AROS systems with ELF64 format.
 +   Copyright (C) 1994, 1995, 1996, 1997, 1998, 1999, 2001, 2002
@@ -710,9 +710,9 @@ diff -ruN gcc-15.2.0/gcc/config/i386/aros64.h gcc-15.2.0.aros/gcc/config/i386/ar
 +#define LINK_SPEC "%{!m32:-m elf_x86_64} %{m32:-m elf_i386} -L %R/lib" 
 +
 +/* FIXME: AROS doesn't support dw2 unwinding yet.  */
-diff -ruN gcc-15.2.0/gcc/config/i386/aros.h gcc-15.2.0.aros/gcc/config/i386/aros.h
---- gcc-15.2.0/gcc/config/i386/aros.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/config/i386/aros.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/i386/aros.h gcc-16.1.0.aros/gcc/config/i386/aros.h
+--- gcc-16.1.0/gcc/config/i386/aros.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/i386/aros.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,25 @@
 +/* Definitions for Intel 386 running AROS systems with ELF format.
 +   Copyright (C) 1994, 1995, 1996, 1997, 1998, 1999, 2001, 2002
@@ -739,10 +739,10 @@ diff -ruN gcc-15.2.0/gcc/config/i386/aros.h gcc-15.2.0.aros/gcc/config/i386/aros
 +
 +#undef	LINK_SPEC
 +#define LINK_SPEC "-m elf_i386 -L%R/lib"
-diff -ruN gcc-15.2.0/gcc/config/m68k/m68k.cc gcc-15.2.0.aros/gcc/config/m68k/m68k.cc
---- gcc-15.2.0/gcc/config/m68k/m68k.cc	2025-08-08 06:51:40.572349774 +0000
-+++ gcc-15.2.0.aros/gcc/config/m68k/m68k.cc	2020-12-27 16:58:14.310000000 +0000
-@@ -5033,7 +5033,7 @@
+diff -ruN gcc-16.1.0/gcc/config/m68k/m68k.cc gcc-16.1.0.aros/gcc/config/m68k/m68k.cc
+--- gcc-16.1.0/gcc/config/m68k/m68k.cc	2026-04-30 08:33:20.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/m68k/m68k.cc	2020-12-27 16:58:14.310000000 +0000
+@@ -5031,7 +5031,7 @@
    else if (letter == '/')
      asm_fprintf (file, "%R");
    else if (letter == '?')
@@ -751,9 +751,9 @@ diff -ruN gcc-15.2.0/gcc/config/m68k/m68k.cc gcc-15.2.0.aros/gcc/config/m68k/m68
    else if (letter == 'p')
      {
        output_addr_const (file, op);
-diff -ruN gcc-15.2.0/gcc/config/m68k/m68k.h gcc-15.2.0.aros/gcc/config/m68k/m68k.h
---- gcc-15.2.0/gcc/config/m68k/m68k.h	2025-08-08 06:51:40.572349774 +0000
-+++ gcc-15.2.0.aros/gcc/config/m68k/m68k.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/m68k/m68k.h gcc-16.1.0.aros/gcc/config/m68k/m68k.h
+--- gcc-16.1.0/gcc/config/m68k/m68k.h	2026-04-30 08:33:20.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/m68k/m68k.h	2020-12-27 16:58:14.310000000 +0000
 @@ -325,7 +325,9 @@
     register elimination.  */
  #define FIRST_PSEUDO_REGISTER 25
@@ -775,9 +775,9 @@ diff -ruN gcc-15.2.0/gcc/config/m68k/m68k.h gcc-15.2.0.aros/gcc/config/m68k/m68k
  
  /* Base register for access to arguments of the function.
   * This isn't a hardware register. It will be eliminated to the
-diff -ruN gcc-15.2.0/gcc/config/m68k/m68k.md gcc-15.2.0.aros/gcc/config/m68k/m68k.md
---- gcc-15.2.0/gcc/config/m68k/m68k.md	2025-08-08 06:51:40.573349790 +0000
-+++ gcc-15.2.0.aros/gcc/config/m68k/m68k.md	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/m68k/m68k.md gcc-16.1.0.aros/gcc/config/m68k/m68k.md
+--- gcc-16.1.0/gcc/config/m68k/m68k.md	2026-04-30 08:33:20.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/m68k/m68k.md	2020-12-27 16:58:14.310000000 +0000
 @@ -133,7 +133,8 @@
    [(D0_REG		0)
     (A0_REG		8)
@@ -788,7 +788,7 @@ diff -ruN gcc-15.2.0/gcc/config/m68k/m68k.md gcc-15.2.0.aros/gcc/config/m68k/m68
     (A6_REG		14)
     (SP_REG		15)
     (FP0_REG		16)
-@@ -6254,7 +6255,7 @@
+@@ -6252,7 +6253,7 @@
  {
    if (TARGET_ID_SHARED_LIBRARY)
      {
@@ -797,15 +797,15 @@ diff -ruN gcc-15.2.0/gcc/config/m68k/m68k.md gcc-15.2.0.aros/gcc/config/m68k/m68
        return MOTOROLA ? "move.l %?(%1),%0" : "movel %1@(%?), %0";
      }
    else if (MOTOROLA)
-diff -ruN gcc-15.2.0/gcc/config/m68k/t-aros gcc-15.2.0.aros/gcc/config/m68k/t-aros
---- gcc-15.2.0/gcc/config/m68k/t-aros	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/config/m68k/t-aros	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/m68k/t-aros gcc-16.1.0.aros/gcc/config/m68k/t-aros
+--- gcc-16.1.0/gcc/config/m68k/t-aros	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/m68k/t-aros	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,2 @@
 +# Custom multilibs for AROS
 +M68K_MLIB_CPU += && match(MLIB, "^68")
-diff -ruN gcc-15.2.0/gcc/config/rs6000/aros.h gcc-15.2.0.aros/gcc/config/rs6000/aros.h
---- gcc-15.2.0/gcc/config/rs6000/aros.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/config/rs6000/aros.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/rs6000/aros.h gcc-16.1.0.aros/gcc/config/rs6000/aros.h
+--- gcc-16.1.0/gcc/config/rs6000/aros.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/rs6000/aros.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,151 @@
 +/* Definitions for Powerpc running AROS systems with ELF format.
 +   Copyright (C) 1994, 1995, 1996, 1997, 1998, 1999, 2001, 2002
@@ -958,9 +958,9 @@ diff -ruN gcc-15.2.0/gcc/config/rs6000/aros.h gcc-15.2.0.aros/gcc/config/rs6000/
 +
 +/* FIXME: AROS doesn't support dw2 unwinding yet.  */
 +#undef MD_FALLBACK_FRAME_STATE_FOR
-diff -ruN gcc-15.2.0/gcc/config/rs6000/rs6000.cc gcc-15.2.0.aros/gcc/config/rs6000/rs6000.cc
---- gcc-15.2.0/gcc/config/rs6000/rs6000.cc	2025-08-08 06:51:40.636350841 +0000
-+++ gcc-15.2.0.aros/gcc/config/rs6000/rs6000.cc	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/rs6000/rs6000.cc gcc-16.1.0.aros/gcc/config/rs6000/rs6000.cc
+--- gcc-16.1.0/gcc/config/rs6000/rs6000.cc	2026-04-30 08:33:20.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/rs6000/rs6000.cc	2020-12-27 16:58:14.310000000 +0000
 @@ -1267,6 +1267,8 @@
      rs6000_handle_longcall_attribute, NULL },
    { "shortcall", 0, 0, false, true,  true,  false,
@@ -970,9 +970,9 @@ diff -ruN gcc-15.2.0/gcc/config/rs6000/rs6000.cc gcc-15.2.0.aros/gcc/config/rs60
    { "ms_struct", 0, 0, false, false, false, false,
      rs6000_handle_struct_attribute, NULL },
    { "gcc_struct", 0, 0, false, false, false, false,
-diff -ruN gcc-15.2.0/gcc/config/rs6000/rs6000.h gcc-15.2.0.aros/gcc/config/rs6000/rs6000.h
---- gcc-15.2.0/gcc/config/rs6000/rs6000.h	2025-08-08 06:51:40.636350841 +0000
-+++ gcc-15.2.0.aros/gcc/config/rs6000/rs6000.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/rs6000/rs6000.h gcc-16.1.0.aros/gcc/config/rs6000/rs6000.h
+--- gcc-16.1.0/gcc/config/rs6000/rs6000.h	2026-04-30 08:33:20.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/rs6000/rs6000.h	2020-12-27 16:58:14.310000000 +0000
 @@ -1464,6 +1464,7 @@
    int nargs_prototype;		/* # args left in the current prototype */
    int prototype;		/* Whether a prototype was defined */
@@ -981,9 +981,9 @@ diff -ruN gcc-15.2.0/gcc/config/rs6000/rs6000.h gcc-15.2.0.aros/gcc/config/rs600
    int call_cookie;		/* Do special things for this call */
    int sysv_gregno;		/* next available GP register */
    int intoffset;		/* running offset in struct (darwin64) */
-diff -ruN gcc-15.2.0/gcc/config/t-aros gcc-15.2.0.aros/gcc/config/t-aros
---- gcc-15.2.0/gcc/config/t-aros	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/config/t-aros	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config/t-aros gcc-16.1.0.aros/gcc/config/t-aros
+--- gcc-16.1.0/gcc/config/t-aros	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config/t-aros	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,31 @@
 +# In AROS, "/usr" is a four-letter word.
 +# Must match NATIVE_SYSTEM_HEADER_COMPONENT in aros.h !
@@ -1016,9 +1016,9 @@ diff -ruN gcc-15.2.0/gcc/config/t-aros gcc-15.2.0.aros/gcc/config/t-aros
 +	  cp $(srcdir)/ginclude/$$file include/$$file; \
 +	  chmod a+r include/$$file; \
 +	done
-diff -ruN gcc-15.2.0/gcc/config.build gcc-15.2.0.aros/gcc/config.build
---- gcc-15.2.0/gcc/config.build	2025-08-08 06:51:40.435347488 +0000
-+++ gcc-15.2.0.aros/gcc/config.build	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config.build gcc-16.1.0.aros/gcc/config.build
+--- gcc-16.1.0/gcc/config.build	2026-04-30 08:33:20.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config.build	2020-12-27 16:58:14.310000000 +0000
 @@ -70,6 +70,9 @@
      build_xm_file=i386/xm-djgpp.h
      build_exeext=.exe
@@ -1029,10 +1029,10 @@ diff -ruN gcc-15.2.0/gcc/config.build gcc-15.2.0.aros/gcc/config.build
    *-*-sysv*)
      # All other System V variants.
      build_install_headers_dir=install-headers-cpio
-diff -ruN gcc-15.2.0/gcc/config.gcc gcc-15.2.0.aros/gcc/config.gcc
---- gcc-15.2.0/gcc/config.gcc	2025-08-08 06:51:40.435347488 +0000
-+++ gcc-15.2.0.aros/gcc/config.gcc	2020-12-27 16:58:14.310000000 +0000
-@@ -993,6 +993,16 @@
+diff -ruN gcc-16.1.0/gcc/config.gcc gcc-16.1.0.aros/gcc/config.gcc
+--- gcc-16.1.0/gcc/config.gcc	2026-04-30 08:33:20.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config.gcc	2020-12-27 16:58:14.310000000 +0000
+@@ -1046,6 +1046,16 @@
    rust_target_objs="${rust_target_objs} netbsd-rust.o"
    target_has_targetrustm=yes
    ;;
@@ -1049,7 +1049,7 @@ diff -ruN gcc-15.2.0/gcc/config.gcc gcc-15.2.0.aros/gcc/config.gcc
  *-*-openbsd*)
    tmake_file="t-openbsd"
    case ${enable_threads} in
-@@ -1186,6 +1196,16 @@
+@@ -1236,6 +1246,16 @@
  esac
  
  case ${target} in
@@ -1066,7 +1066,7 @@ diff -ruN gcc-15.2.0/gcc/config.gcc gcc-15.2.0.aros/gcc/config.gcc
  aarch64*-*-elf | aarch64*-*-fuchsia* | aarch64*-*-rtems*)
  	tm_file="${tm_file} elfos.h newlib-stdint.h"
  	tm_file="${tm_file} aarch64/aarch64-elf.h aarch64/aarch64-errata.h aarch64/aarch64-elf-raw.h"
-@@ -1327,6 +1347,21 @@
+@@ -1380,6 +1400,21 @@
  	tm_file="${tm_file} vms/vms.h alpha/vms.h"
  	tmake_file="${tmake_file} alpha/t-vms alpha/t-alpha"
  	;;
@@ -1088,7 +1088,7 @@ diff -ruN gcc-15.2.0/gcc/config.gcc gcc-15.2.0.aros/gcc/config.gcc
  arc*-*-elf*)
  	tm_file="arc/arc-arch.h elfos.h newlib-stdint.h arc/elf.h ${tm_file}"
  	tmake_file="arc/t-multilib arc/t-arc"
-@@ -2107,6 +2142,16 @@
+@@ -2160,6 +2195,16 @@
  	done
  	TM_MULTILIB_CONFIG=`echo $TM_MULTILIB_CONFIG | sed 's/^,//'`
  	;;
@@ -1105,7 +1105,7 @@ diff -ruN gcc-15.2.0/gcc/config.gcc gcc-15.2.0.aros/gcc/config.gcc
  i[34567]86-pc-msdosdjgpp*)
  	xm_file=i386/xm-djgpp.h
  	tm_file="${tm_file} i386/unix.h i386/bsd.h i386/gas.h i386/djgpp.h i386/djgpp-stdint.h"
-@@ -2402,6 +2447,16 @@
+@@ -2458,6 +2503,16 @@
  m32rle-*-elf*)
  	tm_file="elfos.h newlib-stdint.h m32r/little.h ${tm_file}"
  	;;
@@ -1122,7 +1122,7 @@ diff -ruN gcc-15.2.0/gcc/config.gcc gcc-15.2.0.aros/gcc/config.gcc
  m68k-*-elf* | fido-*-elf*)
  	case ${target} in
  	fido-*-elf*)
-@@ -2519,6 +2574,16 @@
+@@ -2575,6 +2630,16 @@
  	cxx_target_objs="${cxx_target_objs} microblaze-c.o"
  	tmake_file="${tmake_file} microblaze/t-microblaze"
          ;;
@@ -1139,7 +1139,7 @@ diff -ruN gcc-15.2.0/gcc/config.gcc gcc-15.2.0.aros/gcc/config.gcc
  riscv*-*-linux*)
  	tm_file="elfos.h gnu-user.h linux.h glibc-stdint.h ${tm_file} riscv/linux.h"
  	case "x${enable_multilib}" in
-@@ -3060,6 +3125,13 @@
+@@ -3130,6 +3195,13 @@
  	extra_options="${extra_options} rs6000/sysv4.opt rs6000/linux64.opt"
  	tmake_file="${tmake_file} rs6000/t-fprules rs6000/t-rtems rs6000/t-ppccomm"
  	;;
@@ -1153,9 +1153,9 @@ diff -ruN gcc-15.2.0/gcc/config.gcc gcc-15.2.0.aros/gcc/config.gcc
  powerpc*-*-linux*)
  	tm_file="${tm_file} elfos.h gnu-user.h linux.h freebsd-spec.h rs6000/sysv4.h"
  	extra_options="${extra_options} rs6000/sysv4.opt"
-diff -ruN gcc-15.2.0/gcc/config.host gcc-15.2.0.aros/gcc/config.host
---- gcc-15.2.0/gcc/config.host	2025-08-08 06:51:40.435347488 +0000
-+++ gcc-15.2.0.aros/gcc/config.host	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/config.host gcc-16.1.0.aros/gcc/config.host
+--- gcc-16.1.0/gcc/config.host	2026-04-30 08:33:20.000000000 +0000
++++ gcc-16.1.0.aros/gcc/config.host	2020-12-27 16:58:14.310000000 +0000
 @@ -108,7 +108,7 @@
  	;;
      esac
@@ -1165,7 +1165,7 @@ diff -ruN gcc-15.2.0/gcc/config.host gcc-15.2.0.aros/gcc/config.host
      case ${target} in
        arm*-*-*)
  	host_extra_gcc_objs="driver-arm.o"
-@@ -284,6 +284,10 @@
+@@ -288,6 +288,10 @@
      out_host_hook_obj=host-hpux.o
      host_xmake_file="${host_xmake_file} x-hpux"
      ;;
@@ -1176,9 +1176,9 @@ diff -ruN gcc-15.2.0/gcc/config.host gcc-15.2.0.aros/gcc/config.host
    *-*-*vms*)
      host_xm_file="vms/xm-vms.h"
      host_xmake_file=vms/x-vms
-diff -ruN gcc-15.2.0/gcc/cp/g++spec.cc gcc-15.2.0.aros/gcc/cp/g++spec.cc
---- gcc-15.2.0/gcc/cp/g++spec.cc	2025-08-08 06:51:40.705351992 +0000
-+++ gcc-15.2.0.aros/gcc/cp/g++spec.cc	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/cp/g++spec.cc gcc-16.1.0.aros/gcc/cp/g++spec.cc
+--- gcc-16.1.0/gcc/cp/g++spec.cc	2026-04-30 08:33:20.000000000 +0000
++++ gcc-16.1.0.aros/gcc/cp/g++spec.cc	2020-12-27 16:58:14.310000000 +0000
 @@ -50,6 +50,9 @@
  #ifndef LIBSTDCXX_STATIC
  #define LIBSTDCXX_STATIC NULL
@@ -1200,7 +1200,7 @@ diff -ruN gcc-15.2.0/gcc/cp/g++spec.cc gcc-15.2.0.aros/gcc/cp/g++spec.cc
    unsigned int i, j;
  
    /* If nonzero, the user gave us the `-p' or `-pg' flag.  */
-@@ -234,6 +241,8 @@
+@@ -237,6 +244,8 @@
  
  	case OPT_static_libstdc__:
  	  library = library >= 0 ? 2 : library;
@@ -1209,7 +1209,7 @@ diff -ruN gcc-15.2.0/gcc/cp/g++spec.cc gcc-15.2.0.aros/gcc/cp/g++spec.cc
  #ifdef HAVE_LD_STATIC_DYNAMIC
  	  /* Remove -static-libstdc++ from the command only if target supports
  	     LD_STATIC_DYNAMIC.  When not supported, it is left in so that a
-@@ -299,7 +308,10 @@
+@@ -306,7 +315,10 @@
  #ifndef ENABLE_SHARED_LIBGCC
    shared_libgcc = 0;
  #endif
@@ -1220,8 +1220,8 @@ diff -ruN gcc-15.2.0/gcc/cp/g++spec.cc gcc-15.2.0.aros/gcc/cp/g++spec.cc
 +#endif
    /* Add one for shared_libgcc or extra static library.  */
    num_args = (argc + added + need_math + need_experimental
- 	      + (library > 0) * 4 + 1);
-@@ -375,6 +387,12 @@
+ 	      + (std_module * 5)
+@@ -412,6 +424,12 @@
    /* Add `-lstdc++' if we haven't already done so.  */
    if (library > 0)
      {
@@ -1234,7 +1234,7 @@ diff -ruN gcc-15.2.0/gcc/cp/g++spec.cc gcc-15.2.0.aros/gcc/cp/g++spec.cc
        if (need_experimental && which_library == USE_LIBSTDCXX)
  	{
  	  generate_option (OPT_l, "stdc++exp", 1, CL_DRIVER,
-@@ -418,6 +436,13 @@
+@@ -455,6 +473,13 @@
  	  added_libraries++;
  	  j++;
  	}
@@ -1248,7 +1248,7 @@ diff -ruN gcc-15.2.0/gcc/cp/g++spec.cc gcc-15.2.0.aros/gcc/cp/g++spec.cc
  #ifdef HAVE_LD_STATIC_DYNAMIC
        if (library > 1 && !static_link)
  	{
-@@ -444,6 +469,13 @@
+@@ -481,6 +506,13 @@
    if (shared_libgcc && !static_link)
      generate_option (OPT_shared_libgcc, NULL, 1, CL_DRIVER,
  		     &new_decoded_options[j++]);
@@ -1262,37 +1262,37 @@ diff -ruN gcc-15.2.0/gcc/cp/g++spec.cc gcc-15.2.0.aros/gcc/cp/g++spec.cc
  
    *in_decoded_options_count = j;
    *in_decoded_options = new_decoded_options;
-diff -ruN gcc-15.2.0/gcc/ginclude/aros/types/null.h gcc-15.2.0.aros/gcc/ginclude/aros/types/null.h
---- gcc-15.2.0/gcc/ginclude/aros/types/null.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/ginclude/aros/types/null.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/ginclude/aros/types/null.h gcc-16.1.0.aros/gcc/ginclude/aros/types/null.h
+--- gcc-16.1.0/gcc/ginclude/aros/types/null.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/ginclude/aros/types/null.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,3 @@
 +/* Replace AROS' NULL definition with gcc's one */
 +#define __need_NULL
 +#include <stddef.h>
-diff -ruN gcc-15.2.0/gcc/ginclude/aros/types/ptrdiff_t.h gcc-15.2.0.aros/gcc/ginclude/aros/types/ptrdiff_t.h
---- gcc-15.2.0/gcc/ginclude/aros/types/ptrdiff_t.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/ginclude/aros/types/ptrdiff_t.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/ginclude/aros/types/ptrdiff_t.h gcc-16.1.0.aros/gcc/ginclude/aros/types/ptrdiff_t.h
+--- gcc-16.1.0/gcc/ginclude/aros/types/ptrdiff_t.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/ginclude/aros/types/ptrdiff_t.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,3 @@
 +/* Replace AROS' ptrdiff_t definition with gcc's one */
 +#define __need_ptrdiff_t
 +#include <stddef.h>
-diff -ruN gcc-15.2.0/gcc/ginclude/aros/types/size_t.h gcc-15.2.0.aros/gcc/ginclude/aros/types/size_t.h
---- gcc-15.2.0/gcc/ginclude/aros/types/size_t.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/ginclude/aros/types/size_t.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/ginclude/aros/types/size_t.h gcc-16.1.0.aros/gcc/ginclude/aros/types/size_t.h
+--- gcc-16.1.0/gcc/ginclude/aros/types/size_t.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/ginclude/aros/types/size_t.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,3 @@
 +/* Replace AROS' size_t definition with gcc's one */
 +#define __need_size_t
 +#include <stddef.h>
-diff -ruN gcc-15.2.0/gcc/ginclude/aros/types/wchar_t.h gcc-15.2.0.aros/gcc/ginclude/aros/types/wchar_t.h
---- gcc-15.2.0/gcc/ginclude/aros/types/wchar_t.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/gcc/ginclude/aros/types/wchar_t.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/ginclude/aros/types/wchar_t.h gcc-16.1.0.aros/gcc/ginclude/aros/types/wchar_t.h
+--- gcc-16.1.0/gcc/ginclude/aros/types/wchar_t.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/gcc/ginclude/aros/types/wchar_t.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,3 @@
 +/* Replace AROS' wchar_t definition with gcc's one */
 +#define __need_wchar_t
 +#include <stddef.h>
-diff -ruN gcc-15.2.0/gcc/ginclude/stddef.h gcc-15.2.0.aros/gcc/ginclude/stddef.h
---- gcc-15.2.0/gcc/ginclude/stddef.h	2025-08-08 06:51:40.880049726 +0000
-+++ gcc-15.2.0.aros/gcc/ginclude/stddef.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/ginclude/stddef.h gcc-16.1.0.aros/gcc/ginclude/stddef.h
+--- gcc-16.1.0/gcc/ginclude/stddef.h	2026-04-30 08:33:20.000000000 +0000
++++ gcc-16.1.0.aros/gcc/ginclude/stddef.h	2020-12-27 16:58:14.310000000 +0000
 @@ -140,6 +140,7 @@
  #ifndef __PTRDIFF_T
  #ifndef _PTRDIFF_T_
@@ -1365,9 +1365,9 @@ diff -ruN gcc-15.2.0/gcc/ginclude/stddef.h gcc-15.2.0.aros/gcc/ginclude/stddef.h
  #endif
  #endif
  #endif
-diff -ruN gcc-15.2.0/gcc/system.h gcc-15.2.0.aros/gcc/system.h
---- gcc-15.2.0/gcc/system.h	2025-08-08 06:51:41.277361535 +0000
-+++ gcc-15.2.0.aros/gcc/system.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/gcc/system.h gcc-16.1.0.aros/gcc/system.h
+--- gcc-16.1.0/gcc/system.h	2026-04-30 08:33:21.000000000 +0000
++++ gcc-16.1.0.aros/gcc/system.h	2020-12-27 16:58:14.310000000 +0000
 @@ -22,6 +22,11 @@
  #ifndef GCC_SYSTEM_H
  #define GCC_SYSTEM_H
@@ -1380,7 +1380,7 @@ diff -ruN gcc-15.2.0/gcc/system.h gcc-15.2.0.aros/gcc/system.h
  /* Define this so that inttypes.h defines the PRI?64 macros even
     when compiling with a C++ compiler.  Define it here so in the
     event inttypes.h gets pulled in by another header it is already
-@@ -730,9 +735,13 @@
+@@ -733,9 +738,13 @@
  #include "libiberty.h"
  
  #undef FFS  /* Some systems predefine this symbol; don't let it interfere.  */
@@ -1394,9 +1394,9 @@ diff -ruN gcc-15.2.0/gcc/system.h gcc-15.2.0.aros/gcc/system.h
  
  /* Provide a default for the HOST_BIT_BUCKET.
     This suffices for POSIX-like hosts.  */
-diff -ruN gcc-15.2.0/include/filenames.h gcc-15.2.0.aros/include/filenames.h
---- gcc-15.2.0/include/filenames.h	2025-08-08 06:51:44.750419471 +0000
-+++ gcc-15.2.0.aros/include/filenames.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/include/filenames.h gcc-16.1.0.aros/include/filenames.h
+--- gcc-16.1.0/include/filenames.h	2026-04-30 08:33:28.000000000 +0000
++++ gcc-16.1.0.aros/include/filenames.h	2020-12-27 16:58:14.310000000 +0000
 @@ -43,6 +43,13 @@
  #  define HAS_DRIVE_SPEC(f) HAS_DOS_DRIVE_SPEC (f)
  #  define IS_DIR_SEPARATOR(c) IS_DOS_DIR_SEPARATOR (c)
@@ -1411,10 +1411,10 @@ diff -ruN gcc-15.2.0/include/filenames.h gcc-15.2.0.aros/include/filenames.h
  #else /* not DOSish */
  #  if defined(__APPLE__)
  #    ifndef HAVE_CASE_INSENSITIVE_FILE_SYSTEM
-diff -ruN gcc-15.2.0/libatomic/configure.tgt gcc-15.2.0.aros/libatomic/configure.tgt
---- gcc-15.2.0/libatomic/configure.tgt	2025-08-08 06:51:44.759419621 +0000
-+++ gcc-15.2.0.aros/libatomic/configure.tgt	2020-12-27 16:58:14.310000000 +0000
-@@ -128,6 +128,10 @@
+diff -ruN gcc-16.1.0/libatomic/configure.tgt gcc-16.1.0.aros/libatomic/configure.tgt
+--- gcc-16.1.0/libatomic/configure.tgt	2026-04-30 08:33:28.000000000 +0000
++++ gcc-16.1.0.aros/libatomic/configure.tgt	2020-12-27 16:58:14.310000000 +0000
+@@ -152,6 +152,10 @@
  tmake_file=
  # Other system configury
  case "${target}" in
@@ -1425,9 +1425,9 @@ diff -ruN gcc-15.2.0/libatomic/configure.tgt gcc-15.2.0.aros/libatomic/configure
    aarch64*-*-linux*)
  	# OS support for atomic primitives.
  	config_path="${config_path} linux/aarch64 posix"
-diff -ruN gcc-15.2.0/libatomic/libatomic_i.h gcc-15.2.0.aros/libatomic/libatomic_i.h
---- gcc-15.2.0/libatomic/libatomic_i.h	2025-08-08 06:51:44.760419638 +0000
-+++ gcc-15.2.0.aros/libatomic/libatomic_i.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libatomic/libatomic_i.h gcc-16.1.0.aros/libatomic/libatomic_i.h
+--- gcc-16.1.0/libatomic/libatomic_i.h	2026-04-30 08:33:28.000000000 +0000
++++ gcc-16.1.0.aros/libatomic/libatomic_i.h	2020-12-27 16:58:14.310000000 +0000
 @@ -35,6 +35,9 @@
  #include <limits.h>
  #include <string.h>
@@ -1448,15 +1448,15 @@ diff -ruN gcc-15.2.0/libatomic/libatomic_i.h gcc-15.2.0.aros/libatomic/libatomic
  
  /* Macros for handing sub-word sized quantities.  */
  #define MASK_1		((UWORD)0xff)
-diff -ruN gcc-15.2.0/libgcc/config/arm/t-aros gcc-15.2.0.aros/libgcc/config/arm/t-aros
---- gcc-15.2.0/libgcc/config/arm/t-aros	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/libgcc/config/arm/t-aros	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libgcc/config/arm/t-aros gcc-16.1.0.aros/libgcc/config/arm/t-aros
+--- gcc-16.1.0/libgcc/config/arm/t-aros	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/libgcc/config/arm/t-aros	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,2 @@
 +LIB1ASMFUNCS += _udivsi3 _divsi3 _umodsi3 _modsi3 _dvmd_tls
 +
-diff -ruN gcc-15.2.0/libgcc/config/m68k/aros-atomic.c gcc-15.2.0.aros/libgcc/config/m68k/aros-atomic.c
---- gcc-15.2.0/libgcc/config/m68k/aros-atomic.c	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/libgcc/config/m68k/aros-atomic.c	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libgcc/config/m68k/aros-atomic.c gcc-16.1.0.aros/libgcc/config/m68k/aros-atomic.c
+--- gcc-16.1.0/libgcc/config/m68k/aros-atomic.c	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/libgcc/config/m68k/aros-atomic.c	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,204 @@
 +/* AROS-specific atomic operations for m68k AROS.
 +   Copyright (C) 2019 Free Software Foundation, Inc.
@@ -1662,18 +1662,18 @@ diff -ruN gcc-15.2.0/libgcc/config/m68k/aros-atomic.c gcc-15.2.0.aros/libgcc/con
 +WORD_SYNC_OP (test_and_set, , COMMA, oldval)
 +SUBWORD_SYNC_OP (test_and_set, , COMMA, unsigned char, 1, oldval)
 +SUBWORD_SYNC_OP (test_and_set, , COMMA, unsigned short, 2, oldval)
-diff -ruN gcc-15.2.0/libgcc/config/m68k/t-aros gcc-15.2.0.aros/libgcc/config/m68k/t-aros
---- gcc-15.2.0/libgcc/config/m68k/t-aros	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/libgcc/config/m68k/t-aros	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libgcc/config/m68k/t-aros gcc-16.1.0.aros/libgcc/config/m68k/t-aros
+--- gcc-16.1.0/libgcc/config/m68k/t-aros	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/libgcc/config/m68k/t-aros	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,4 @@
 +
 +aros-atomic.o: $(srcdir)/config/m68k/aros-atomic.c
 +	$(gcc_compile) -mcpu=68020 -c $<
 +libgcc-objects += aros-atomic.o
-diff -ruN gcc-15.2.0/libgcc/config.host gcc-15.2.0.aros/libgcc/config.host
---- gcc-15.2.0/libgcc/config.host	2025-08-08 06:51:44.833420855 +0000
-+++ gcc-15.2.0.aros/libgcc/config.host	2020-12-27 16:58:14.310000000 +0000
-@@ -527,6 +527,12 @@
+diff -ruN gcc-16.1.0/libgcc/config.host gcc-16.1.0.aros/libgcc/config.host
+--- gcc-16.1.0/libgcc/config.host	2026-04-30 08:33:28.000000000 +0000
++++ gcc-16.1.0.aros/libgcc/config.host	2020-12-27 16:58:14.310000000 +0000
+@@ -517,6 +517,12 @@
  	unwind_header=config/arm/unwind-arm.h
  	extra_parts="$extra_parts crti.o crtn.o"
  	;;
@@ -1686,7 +1686,7 @@ diff -ruN gcc-15.2.0/libgcc/config.host gcc-15.2.0.aros/libgcc/config.host
  arm*-*-freebsd*)                # ARM FreeBSD EABI
  	tmake_file="${tmake_file} arm/t-arm t-fixedpoint-gnu-prefix arm/t-elf"
  	tmake_file="${tmake_file} arm/t-bpabi arm/t-freebsd"
-@@ -1020,6 +1026,9 @@
+@@ -1018,6 +1024,9 @@
  m32rle-*-elf*)
  	tmake_file=t-fdpbit
  	;;
@@ -1696,7 +1696,7 @@ diff -ruN gcc-15.2.0/libgcc/config.host gcc-15.2.0.aros/libgcc/config.host
  m68k-*-elf* | fido-*-elf)
  	tmake_file="$tmake_file m68k/t-floatlib"
  	;;
-@@ -1571,6 +1580,9 @@
+@@ -1574,6 +1583,9 @@
  	tmake_file="$tmake_file nvptx/t-nvptx"
  	extra_parts="crt0.o"
  	;;
@@ -1706,9 +1706,9 @@ diff -ruN gcc-15.2.0/libgcc/config.host gcc-15.2.0.aros/libgcc/config.host
  *)
  	echo "*** Configuration ${host} not supported" 1>&2
  	exit 1
-diff -ruN gcc-15.2.0/libgcc/gthr.h gcc-15.2.0.aros/libgcc/gthr.h
---- gcc-15.2.0/libgcc/gthr.h	2025-08-08 06:51:44.917422256 +0000
-+++ gcc-15.2.0.aros/libgcc/gthr.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libgcc/gthr.h gcc-16.1.0.aros/libgcc/gthr.h
+--- gcc-16.1.0/libgcc/gthr.h	2026-04-30 08:33:28.000000000 +0000
++++ gcc-16.1.0.aros/libgcc/gthr.h	2020-12-27 16:58:14.310000000 +0000
 @@ -150,6 +150,11 @@
  #endif
  #endif
@@ -1721,9 +1721,9 @@ diff -ruN gcc-15.2.0/libgcc/gthr.h gcc-15.2.0.aros/libgcc/gthr.h
  #ifndef GTHREAD_USE_WEAK
  #define GTHREAD_USE_WEAK 1
  #endif
-diff -ruN gcc-15.2.0/libgcc/unwind-dw2.c gcc-15.2.0.aros/libgcc/unwind-dw2.c
---- gcc-15.2.0/libgcc/unwind-dw2.c	2025-08-08 06:51:44.926422406 +0000
-+++ gcc-15.2.0.aros/libgcc/unwind-dw2.c	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libgcc/unwind-dw2.c gcc-16.1.0.aros/libgcc/unwind-dw2.c
+--- gcc-16.1.0/libgcc/unwind-dw2.c	2026-04-30 08:33:28.000000000 +0000
++++ gcc-16.1.0.aros/libgcc/unwind-dw2.c	2020-12-27 16:58:14.310000000 +0000
 @@ -1322,7 +1322,9 @@
  static inline void
  init_dwarf_reg_size_table (void)
@@ -1734,9 +1734,9 @@ diff -ruN gcc-15.2.0/libgcc/unwind-dw2.c gcc-15.2.0.aros/libgcc/unwind-dw2.c
  }
  
  static void __attribute__((noinline))
-diff -ruN gcc-15.2.0/libgcc/unwind-dw2-fde.c gcc-15.2.0.aros/libgcc/unwind-dw2-fde.c
---- gcc-15.2.0/libgcc/unwind-dw2-fde.c	2025-08-08 06:51:44.926422406 +0000
-+++ gcc-15.2.0.aros/libgcc/unwind-dw2-fde.c	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libgcc/unwind-dw2-fde.c gcc-16.1.0.aros/libgcc/unwind-dw2-fde.c
+--- gcc-16.1.0/libgcc/unwind-dw2-fde.c	2026-04-30 08:33:28.000000000 +0000
++++ gcc-16.1.0.aros/libgcc/unwind-dw2-fde.c	2020-12-27 16:58:14.310000000 +0000
 @@ -144,13 +144,17 @@
    register_pc_range_for_object ((uintptr_type) begin, ob);
  #else
@@ -1756,9 +1756,9 @@ diff -ruN gcc-15.2.0/libgcc/unwind-dw2-fde.c gcc-15.2.0.aros/libgcc/unwind-dw2-f
  }
  
  void
-diff -ruN gcc-15.2.0/libiberty/filename_cmp.c gcc-15.2.0.aros/libiberty/filename_cmp.c
---- gcc-15.2.0/libiberty/filename_cmp.c	2025-08-08 06:51:45.463431365 +0000
-+++ gcc-15.2.0.aros/libiberty/filename_cmp.c	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libiberty/filename_cmp.c gcc-16.1.0.aros/libiberty/filename_cmp.c
+--- gcc-16.1.0/libiberty/filename_cmp.c	2026-04-30 08:33:29.000000000 +0000
++++ gcc-16.1.0.aros/libiberty/filename_cmp.c	2020-12-27 16:58:14.310000000 +0000
 @@ -55,9 +55,12 @@
  int
  filename_cmp (const char *s1, const char *s2)
@@ -1774,10 +1774,10 @@ diff -ruN gcc-15.2.0/libiberty/filename_cmp.c gcc-15.2.0.aros/libiberty/filename
  #else
    for (;;)
      {
-diff -ruN gcc-15.2.0/libobjc/configure gcc-15.2.0.aros/libobjc/configure
---- gcc-15.2.0/libobjc/configure	2025-08-08 06:51:45.484431715 +0000
-+++ gcc-15.2.0.aros/libobjc/configure	2020-12-27 16:58:14.310000000 +0000
-@@ -11434,217 +11434,6 @@
+diff -ruN gcc-16.1.0/libobjc/configure gcc-16.1.0.aros/libobjc/configure
+--- gcc-16.1.0/libobjc/configure	2026-04-30 08:33:29.000000000 +0000
++++ gcc-16.1.0.aros/libobjc/configure	2020-12-27 16:58:14.310000000 +0000
+@@ -11823,217 +11823,6 @@
  # Miscellanea
  # -----------
  
@@ -1995,9 +1995,9 @@ diff -ruN gcc-15.2.0/libobjc/configure gcc-15.2.0.aros/libobjc/configure
    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if the type of bitfields matters" >&5
  $as_echo_n "checking if the type of bitfields matters... " >&6; }
  if ${gt_cv_bitfield_type_matters+:} false; then :
-diff -ruN gcc-15.2.0/libobjc/configure.ac gcc-15.2.0.aros/libobjc/configure.ac
---- gcc-15.2.0/libobjc/configure.ac	2025-08-08 06:51:45.484431715 +0000
-+++ gcc-15.2.0.aros/libobjc/configure.ac	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libobjc/configure.ac gcc-16.1.0.aros/libobjc/configure.ac
+--- gcc-16.1.0/libobjc/configure.ac	2026-04-30 08:33:29.000000000 +0000
++++ gcc-16.1.0.aros/libobjc/configure.ac	2020-12-27 16:58:14.310000000 +0000
 @@ -218,7 +218,7 @@
  # -----------
  
@@ -2007,9 +2007,9 @@ diff -ruN gcc-15.2.0/libobjc/configure.ac gcc-15.2.0.aros/libobjc/configure.ac
  
  gt_BITFIELD_TYPE_MATTERS
  
-diff -ruN gcc-15.2.0/libobjc/thr.c gcc-15.2.0.aros/libobjc/thr.c
---- gcc-15.2.0/libobjc/thr.c	2025-08-08 06:51:45.487445109 +0000
-+++ gcc-15.2.0.aros/libobjc/thr.c	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libobjc/thr.c gcc-16.1.0.aros/libobjc/thr.c
+--- gcc-16.1.0/libobjc/thr.c	2026-04-30 08:33:29.000000000 +0000
++++ gcc-16.1.0.aros/libobjc/thr.c	2020-12-27 16:58:14.310000000 +0000
 @@ -35,6 +35,7 @@
  #include "objc/runtime.h"
  #include "objc-private/module-abi-8.h"
@@ -2018,9 +2018,9 @@ diff -ruN gcc-15.2.0/libobjc/thr.c gcc-15.2.0.aros/libobjc/thr.c
  #include <gthr.h>
  
  #include <stdlib.h>
-diff -ruN gcc-15.2.0/libquadmath/printf/quadmath-printf.h gcc-15.2.0.aros/libquadmath/printf/quadmath-printf.h
---- gcc-15.2.0/libquadmath/printf/quadmath-printf.h	2025-08-08 06:51:45.597059726 +0000
-+++ gcc-15.2.0.aros/libquadmath/printf/quadmath-printf.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libquadmath/printf/quadmath-printf.h gcc-16.1.0.aros/libquadmath/printf/quadmath-printf.h
+--- gcc-16.1.0/libquadmath/printf/quadmath-printf.h	2026-04-30 08:33:29.000000000 +0000
++++ gcc-16.1.0.aros/libquadmath/printf/quadmath-printf.h	2020-12-27 16:58:14.310000000 +0000
 @@ -138,6 +138,7 @@
    size_t len;
    if (fp->file_p)
@@ -2051,9 +2051,9 @@ diff -ruN gcc-15.2.0/libquadmath/printf/quadmath-printf.h gcc-15.2.0.aros/libqua
    if (fp->size)
      {
        *(fp->str++) = c;
-diff -ruN gcc-15.2.0/libstdc++-v3/config/os/aros/ctype_base.h gcc-15.2.0.aros/libstdc++-v3/config/os/aros/ctype_base.h
---- gcc-15.2.0/libstdc++-v3/config/os/aros/ctype_base.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/libstdc++-v3/config/os/aros/ctype_base.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libstdc++-v3/config/os/aros/ctype_base.h gcc-16.1.0.aros/libstdc++-v3/config/os/aros/ctype_base.h
+--- gcc-16.1.0/libstdc++-v3/config/os/aros/ctype_base.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/libstdc++-v3/config/os/aros/ctype_base.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,30 @@
 +namespace std _GLIBCXX_VISIBILITY(default)
 +{
@@ -2085,9 +2085,9 @@ diff -ruN gcc-15.2.0/libstdc++-v3/config/os/aros/ctype_base.h gcc-15.2.0.aros/li
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-15.2.0/libstdc++-v3/config/os/aros/ctype_configure_char.cc gcc-15.2.0.aros/libstdc++-v3/config/os/aros/ctype_configure_char.cc
---- gcc-15.2.0/libstdc++-v3/config/os/aros/ctype_configure_char.cc	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/libstdc++-v3/config/os/aros/ctype_configure_char.cc	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libstdc++-v3/config/os/aros/ctype_configure_char.cc gcc-16.1.0.aros/libstdc++-v3/config/os/aros/ctype_configure_char.cc
+--- gcc-16.1.0/libstdc++-v3/config/os/aros/ctype_configure_char.cc	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/libstdc++-v3/config/os/aros/ctype_configure_char.cc	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,99 @@
 +// Locale support -*- C++ -*-
 +
@@ -2188,9 +2188,9 @@ diff -ruN gcc-15.2.0/libstdc++-v3/config/os/aros/ctype_configure_char.cc gcc-15.
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-15.2.0/libstdc++-v3/config/os/aros/ctype_inline.h gcc-15.2.0.aros/libstdc++-v3/config/os/aros/ctype_inline.h
---- gcc-15.2.0/libstdc++-v3/config/os/aros/ctype_inline.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/libstdc++-v3/config/os/aros/ctype_inline.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libstdc++-v3/config/os/aros/ctype_inline.h gcc-16.1.0.aros/libstdc++-v3/config/os/aros/ctype_inline.h
+--- gcc-16.1.0/libstdc++-v3/config/os/aros/ctype_inline.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/libstdc++-v3/config/os/aros/ctype_inline.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,173 @@
 +// Locale support -*- C++ -*-
 +
@@ -2365,9 +2365,9 @@ diff -ruN gcc-15.2.0/libstdc++-v3/config/os/aros/ctype_inline.h gcc-15.2.0.aros/
 +
 +_GLIBCXX_END_NAMESPACE_VERSION
 +} // namespace
-diff -ruN gcc-15.2.0/libstdc++-v3/config/os/aros/ctype_noninline.h gcc-15.2.0.aros/libstdc++-v3/config/os/aros/ctype_noninline.h
---- gcc-15.2.0/libstdc++-v3/config/os/aros/ctype_noninline.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/libstdc++-v3/config/os/aros/ctype_noninline.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libstdc++-v3/config/os/aros/ctype_noninline.h gcc-16.1.0.aros/libstdc++-v3/config/os/aros/ctype_noninline.h
+--- gcc-16.1.0/libstdc++-v3/config/os/aros/ctype_noninline.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/libstdc++-v3/config/os/aros/ctype_noninline.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,56 @@
 +  const ctype_base::mask*
 +  ctype<char>::classic_table() throw()
@@ -2425,9 +2425,9 @@ diff -ruN gcc-15.2.0/libstdc++-v3/config/os/aros/ctype_noninline.h gcc-15.2.0.ar
 +      }
 +    return __high;
 +  }
-diff -ruN gcc-15.2.0/libstdc++-v3/config/os/aros/os_defines.h gcc-15.2.0.aros/libstdc++-v3/config/os/aros/os_defines.h
---- gcc-15.2.0/libstdc++-v3/config/os/aros/os_defines.h	1970-01-01 00:00:00.000000000 +0000
-+++ gcc-15.2.0.aros/libstdc++-v3/config/os/aros/os_defines.h	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libstdc++-v3/config/os/aros/os_defines.h gcc-16.1.0.aros/libstdc++-v3/config/os/aros/os_defines.h
+--- gcc-16.1.0/libstdc++-v3/config/os/aros/os_defines.h	1970-01-01 00:00:00.000000000 +0000
++++ gcc-16.1.0.aros/libstdc++-v3/config/os/aros/os_defines.h	2020-12-27 16:58:14.310000000 +0000
 @@ -0,0 +1,12 @@
 +// Specific definitions for AROS  -*- C++ -*-
 +
@@ -2441,14 +2441,15 @@ diff -ruN gcc-15.2.0/libstdc++-v3/config/os/aros/os_defines.h gcc-15.2.0.aros/li
 +#define POSIXC_NOINLINE_VAARGS
 +
 +#endif
-diff -ruN gcc-15.2.0/libstdc++-v3/configure gcc-15.2.0.aros/libstdc++-v3/configure
---- gcc-15.2.0/libstdc++-v3/configure	2025-08-08 06:51:45.690435151 +0000
-+++ gcc-15.2.0.aros/libstdc++-v3/configure	2020-12-27 16:58:14.310000000 +0000
-@@ -5942,14 +5942,14 @@
+diff -ruN gcc-16.1.0/libstdc++-v3/configure gcc-16.1.0.aros/libstdc++-v3/configure
+--- gcc-16.1.0/libstdc++-v3/configure	2026-04-30 08:34:44.000000000 +0000
++++ gcc-16.1.0.aros/libstdc++-v3/configure	2020-12-27 16:58:14.310000000 +0000
+@@ -5952,15 +5952,15 @@
  
  
  # Libtool setup.
 -if test "x${with_newlib}" != "xyes" &&
+-    test "x${with_picolibc}" != "xyes" &&
 -    test "x${with_avrlibc}" != "xyes" &&
 -    test "x$with_headers" != "xno"; then
 -  enable_dlopen=yes
@@ -2457,6 +2458,7 @@ diff -ruN gcc-15.2.0/libstdc++-v3/configure gcc-15.2.0.aros/libstdc++-v3/configu
 -
 -fi
 +#if test "x${with_newlib}" != "xyes" &&
++#    test "x${with_picolibc}" != "xyes" &&
 +#    test "x${with_avrlibc}" != "xyes" &&
 +#    test "x$with_headers" != "xno"; then
 +#  enable_dlopen=yes
@@ -2467,7 +2469,7 @@ diff -ruN gcc-15.2.0/libstdc++-v3/configure gcc-15.2.0.aros/libstdc++-v3/configu
  case `pwd` in
    *\ * | *\	*)
      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Libtool does not cope well with whitespace in \`pwd\`" >&5
-@@ -8724,6 +8724,8 @@
+@@ -9123,6 +9123,8 @@
  
  
  
@@ -2476,7 +2478,7 @@ diff -ruN gcc-15.2.0/libstdc++-v3/configure gcc-15.2.0.aros/libstdc++-v3/configu
  
    enable_win32_dll=no
  
-@@ -20460,6 +20462,7 @@
+@@ -20629,6 +20631,7 @@
  {
  struct iovec iov[2];
         writev(0, iov, 0);
@@ -2484,7 +2486,7 @@ diff -ruN gcc-15.2.0/libstdc++-v3/configure gcc-15.2.0.aros/libstdc++-v3/configu
    ;
    return 0;
  }
-@@ -20482,6 +20485,7 @@
+@@ -20651,6 +20654,7 @@
  {
  struct iovec iov[2];
         writev(0, iov, 0);
@@ -2492,7 +2494,7 @@ diff -ruN gcc-15.2.0/libstdc++-v3/configure gcc-15.2.0.aros/libstdc++-v3/configu
    ;
    return 0;
  }
-@@ -28650,6 +28654,58 @@
+@@ -28975,6 +28979,58 @@
  
  # Base decisions on target environment.
  case "${host}" in
@@ -2551,19 +2553,21 @@ diff -ruN gcc-15.2.0/libstdc++-v3/configure gcc-15.2.0.aros/libstdc++-v3/configu
    arm*-*-symbianelf*)
      # This is a freestanding configuration; there is nothing to do here.
      ;;
-diff -ruN gcc-15.2.0/libstdc++-v3/configure.ac gcc-15.2.0.aros/libstdc++-v3/configure.ac
---- gcc-15.2.0/libstdc++-v3/configure.ac	2025-08-08 06:51:45.690435151 +0000
-+++ gcc-15.2.0.aros/libstdc++-v3/configure.ac	2020-12-27 16:58:14.310000000 +0000
-@@ -99,11 +99,11 @@
+diff -ruN gcc-16.1.0/libstdc++-v3/configure.ac gcc-16.1.0.aros/libstdc++-v3/configure.ac
+--- gcc-16.1.0/libstdc++-v3/configure.ac	2026-04-30 08:33:29.000000000 +0000
++++ gcc-16.1.0.aros/libstdc++-v3/configure.ac	2020-12-27 16:58:14.310000000 +0000
+@@ -99,12 +99,12 @@
  GLIBCXX_CONFIGURE
  
  # Libtool setup.
 -if test "x${with_newlib}" != "xyes" &&
+-    test "x${with_picolibc}" != "xyes" &&
 -    test "x${with_avrlibc}" != "xyes" &&
 -    test "x$with_headers" != "xno"; then
 -  AC_LIBTOOL_DLOPEN
 -fi
 +#if test "x${with_newlib}" != "xyes" &&
++#    test "x${with_picolibc}" != "xyes" &&
 +#    test "x${with_avrlibc}" != "xyes" &&
 +#    test "x$with_headers" != "xno"; then
 +#  AC_LIBTOOL_DLOPEN
@@ -2571,9 +2575,9 @@ diff -ruN gcc-15.2.0/libstdc++-v3/configure.ac gcc-15.2.0.aros/libstdc++-v3/conf
  AM_PROG_LIBTOOL
  ACX_LT_HOST_FLAGS
  AC_SUBST(enable_shared)
-diff -ruN gcc-15.2.0/libstdc++-v3/configure.host gcc-15.2.0.aros/libstdc++-v3/configure.host
---- gcc-15.2.0/libstdc++-v3/configure.host	2025-08-08 06:51:45.691435169 +0000
-+++ gcc-15.2.0.aros/libstdc++-v3/configure.host	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libstdc++-v3/configure.host gcc-16.1.0.aros/libstdc++-v3/configure.host
+--- gcc-16.1.0/libstdc++-v3/configure.host	2026-04-30 08:33:29.000000000 +0000
++++ gcc-16.1.0.aros/libstdc++-v3/configure.host	2020-12-27 16:58:14.310000000 +0000
 @@ -226,6 +226,9 @@
      os_include_dir="os/generic"
      atomicity_dir="cpu/generic"
@@ -2584,9 +2588,9 @@ diff -ruN gcc-15.2.0/libstdc++-v3/configure.host gcc-15.2.0.aros/libstdc++-v3/co
    bsd*)
      # Plain BSD attempts to share FreeBSD files.
      os_include_dir="os/bsd/freebsd"
-diff -ruN gcc-15.2.0/libstdc++-v3/crossconfig.m4 gcc-15.2.0.aros/libstdc++-v3/crossconfig.m4
---- gcc-15.2.0/libstdc++-v3/crossconfig.m4	2025-08-08 06:51:45.691435169 +0000
-+++ gcc-15.2.0.aros/libstdc++-v3/crossconfig.m4	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libstdc++-v3/crossconfig.m4 gcc-16.1.0.aros/libstdc++-v3/crossconfig.m4
+--- gcc-16.1.0/libstdc++-v3/crossconfig.m4	2026-04-30 08:33:29.000000000 +0000
++++ gcc-16.1.0.aros/libstdc++-v3/crossconfig.m4	2020-12-27 16:58:14.310000000 +0000
 @@ -5,6 +5,31 @@
  AC_DEFUN([GLIBCXX_CROSSCONFIG],[
  # Base decisions on target environment.
@@ -2619,9 +2623,9 @@ diff -ruN gcc-15.2.0/libstdc++-v3/crossconfig.m4 gcc-15.2.0.aros/libstdc++-v3/cr
    arm*-*-symbianelf*)
      # This is a freestanding configuration; there is nothing to do here.
      ;;
-diff -ruN gcc-15.2.0/libstdc++-v3/include/c_global/cstdint gcc-15.2.0.aros/libstdc++-v3/include/c_global/cstdint
---- gcc-15.2.0/libstdc++-v3/include/c_global/cstdint	2025-08-08 06:51:45.776484451 +0000
-+++ gcc-15.2.0.aros/libstdc++-v3/include/c_global/cstdint	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libstdc++-v3/include/c_global/cstdint gcc-16.1.0.aros/libstdc++-v3/include/c_global/cstdint
+--- gcc-16.1.0/libstdc++-v3/include/c_global/cstdint	2026-04-30 08:33:29.000000000 +0000
++++ gcc-16.1.0.aros/libstdc++-v3/include/c_global/cstdint	2020-12-27 16:58:14.310000000 +0000
 @@ -79,8 +79,10 @@
    using ::uint_fast64_t;
  
@@ -2633,10 +2637,10 @@ diff -ruN gcc-15.2.0/libstdc++-v3/include/c_global/cstdint gcc-15.2.0.aros/libst
    using ::uint_least64_t;
  
    using ::uintmax_t;
-diff -ruN gcc-15.2.0/libstdc++-v3/include/Makefile.in gcc-15.2.0.aros/libstdc++-v3/include/Makefile.in
---- gcc-15.2.0/libstdc++-v3/include/Makefile.in	2025-08-08 06:51:45.751777211 +0000
-+++ gcc-15.2.0.aros/libstdc++-v3/include/Makefile.in	2020-12-27 16:58:14.310000000 +0000
-@@ -1910,6 +1910,7 @@
+diff -ruN gcc-16.1.0/libstdc++-v3/include/Makefile.in gcc-16.1.0.aros/libstdc++-v3/include/Makefile.in
+--- gcc-16.1.0/libstdc++-v3/include/Makefile.in	2026-04-30 08:33:29.000000000 +0000
++++ gcc-16.1.0.aros/libstdc++-v3/include/Makefile.in	2020-12-27 16:58:14.310000000 +0000
+@@ -1943,6 +1943,7 @@
  	    -e '/^#/s/\(${uppercase}${uppercase}*\)/_GLIBCXX_\1/g' \
  	    -e 's/_GLIBCXX_SUPPORTS_WEAK/__GXX_WEAK__/g' \
  	    -e 's/_GLIBCXX___MINGW32_GLIBCXX___/__MINGW32__/g' \
@@ -2644,9 +2648,9 @@ diff -ruN gcc-15.2.0/libstdc++-v3/include/Makefile.in gcc-15.2.0.aros/libstdc++-
  	    -e 's,^#include "\(.*\)",#include <bits/\1>,g' \
  	    < $< > $@
  
-diff -ruN gcc-15.2.0/libstdc++-v3/include/std/ratio gcc-15.2.0.aros/libstdc++-v3/include/std/ratio
---- gcc-15.2.0/libstdc++-v3/include/std/ratio	2025-08-08 06:51:45.815437237 +0000
-+++ gcc-15.2.0.aros/libstdc++-v3/include/std/ratio	2020-12-27 16:58:14.310000000 +0000
+diff -ruN gcc-16.1.0/libstdc++-v3/include/std/ratio gcc-16.1.0.aros/libstdc++-v3/include/std/ratio
+--- gcc-16.1.0/libstdc++-v3/include/std/ratio	2026-04-30 08:33:29.000000000 +0000
++++ gcc-16.1.0.aros/libstdc++-v3/include/std/ratio	2020-12-27 16:58:14.310000000 +0000
 @@ -217,10 +217,10 @@
      {
      private:


### PR DESCRIPTION
Re-do of #245, scoped down per your feedback and targeting `exp-gcc-16`.

**One commit, compiler patch only:**
- Adds `tools/crosstools/gnu/gcc-16.1.0-aros.diff` (crt-based `aros.h` port) and updates `gcc-15.2.0-aros.diff` to match.
- **`config/gcc_def` / `config/gcc_exp` are left unchanged** — no default-version bump, so this can be evaluated on its own as you suggested.
- Dropped the `posixc`/`__vfork.c` and `collect-aros` changes you flagged (those are native-compiler / stage-2 concerns and don't build the C library in this repo), and the unrelated `debug.library` fix.

**The one carried fix worth calling out** — the x86_64 `aros64.h` restores the `FIXED_REGISTERS` override reserving **r12**: the proto-inline LVO sequence loads the system library base into r12 before each call, and without r12 fixed, GCC 16 under `-mcmodel=large` mis-schedules its save/restore so the LVO runs with the wrong base (wild jump / Privilege violation). Pure-dispatch code is unaffected, which is why it only shows up once a library calls a system LVO.

Authored solely by me (no AI co-author trailer).

Happy to run the full validation process if you want to point me at the test suite; otherwise this is the standalone compiler patch for review. Supersedes #245, which I'll close.
