### PR TITLE
crosstools: fix GCC 16.1.0 core-linux-x86_64-d build (libatomic, -noclibs, static C++ runtime)

### DIFF
--- a/tools/crosstools/gnu/gcc-16.1.0-aros.diff
+++ b/tools/crosstools/gnu/gcc-16.1.0-aros.diff
@@ -227,7 +227,7 @@ diff -ruN gcc-16.1.0/gcc/config/aarch64/aros.h gcc-16.1.0.aros/gcc/config/aarch6
 +#endif
 +
 +#undef SUBTARGET_CPP_SPEC
-+#define SUBTARGET_CPP_SPEC "-D__ELF__ %{!nostdinc:%{!nostdc:%{!noposixc|noposixinc: -idirafter %R/include/aros/posixc} -idirafter %R/include/aros/stdc}}"
++#define SUBTARGET_CPP_SPEC "-D__ELF__ %{!nostdinc: -idirafter %R/include/aros/posixc -idirafter %R/include/aros/stdc}"
 +
 +#undef  SUBTARGET_EXTRA_LINK_SPEC
 +#define SUBTARGET_EXTRA_LINK_SPEC " -m " TARGET_LINKER_EMULATION
@@ -336,7 +336,7 @@ diff -ruN gcc-16.1.0/gcc/config/arm/aros.h gcc-16.1.0.aros/gcc/config/arm/aros.h
 +#endif
 +
 +#undef SUBTARGET_CPP_SPEC
-+#define SUBTARGET_CPP_SPEC "-D__ELF__ %{!nostdinc:%{!nostdc:%{!noposixc|noposixinc: -idirafter %R/include/aros/posixc} -idirafter %R/include/aros/stdc}}"
++#define SUBTARGET_CPP_SPEC "-D__ELF__ %{!nostdinc: -idirafter %R/include/aros/posixc -idirafter %R/include/aros/stdc}"
 +
 +#undef  SUBTARGET_EXTRA_LINK_SPEC
 +#define SUBTARGET_EXTRA_LINK_SPEC " -m " TARGET_LINKER_EMULATION
@@ -565,7 +565,7 @@ diff -Naur gcc-16.1.0/gcc/config/aros.h gcc-16.1.0.aros/gcc/config/aros.h
 diff -ruN gcc-16.1.0/gcc/config/aros.opt gcc-16.1.0.aros/gcc/config/aros.opt
 --- gcc-16.1.0/gcc/config/aros.opt	1970-01-01 00:00:00.000000000 +0000
 +++ gcc-16.1.0.aros/gcc/config/aros.opt	2020-12-27 16:58:14.310000000 +0000
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,32 @@
 +; Processor-independent options for AROS.
 +
 +; Copyright (C) 2015 Free Software Foundation, Inc.
@@ -590,18 +590,6 @@ diff -ruN gcc-16.1.0/gcc/config/aros.opt gcc-16.1.0.aros/gcc/config/aros.opt
 +Driver
 +
 +noclibs
-+Driver
-+
-+noposixc
-+Driver
-+
-+noposixinc
-+Driver
-+
-+deferposixc
-+Driver
-+
-+nostdc
 +Driver
 +
 +nosysbase

--- a/tools/crosstools/gnu/gcc-16.1.0-aros.diff
+++ b/tools/crosstools/gnu/gcc-16.1.0-aros.diff
@@ -565,7 +565,7 @@ diff -Naur gcc-16.1.0/gcc/config/aros.h gcc-16.1.0.aros/gcc/config/aros.h
 diff -ruN gcc-16.1.0/gcc/config/aros.opt gcc-16.1.0.aros/gcc/config/aros.opt
 --- gcc-16.1.0/gcc/config/aros.opt	1970-01-01 00:00:00.000000000 +0000
 +++ gcc-16.1.0.aros/gcc/config/aros.opt	2020-12-27 16:58:14.310000000 +0000
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,44 @@
 +; Processor-independent options for AROS.
 +
 +; Copyright (C) 2015 Free Software Foundation, Inc.
@@ -587,6 +587,9 @@ diff -ruN gcc-16.1.0/gcc/config/aros.opt gcc-16.1.0.aros/gcc/config/aros.opt
 +; <http://www.gnu.org/licenses/>.
 +
 +posix
++Driver
++
++noclibs
 +Driver
 +
 +noposixc

--- a/tools/crosstools/gnu/gcc-16.1.0-aros.diff
+++ b/tools/crosstools/gnu/gcc-16.1.0-aros.diff
@@ -1182,89 +1182,48 @@ diff -ruN gcc-16.1.0/gcc/config.host gcc-16.1.0.aros/gcc/config.host
 diff -ruN gcc-16.1.0/gcc/cp/g++spec.cc gcc-16.1.0.aros/gcc/cp/g++spec.cc
 --- gcc-16.1.0/gcc/cp/g++spec.cc	2026-04-30 08:33:20.000000000 +0000
 +++ gcc-16.1.0.aros/gcc/cp/g++spec.cc	2020-12-27 16:58:14.310000000 +0000
-@@ -50,6 +50,9 @@
- #ifndef LIBSTDCXX_STATIC
- #define LIBSTDCXX_STATIC NULL
- #endif
-+#ifndef LIBSTDCXX_PTHREAD
-+#define LIBSTDCXX_PTHREAD NULL
-+#endif
- 
- #ifndef LIBCXX
- #define LIBCXX "c++"
-@@ -84,6 +87,10 @@
- 		      unsigned int *in_decoded_options_count,
- 		      int *in_added_libraries)
- {
-+#ifdef LIBSTDCXX_CIRCULAR
-+  int started = 0;
-+#endif
-+
-   unsigned int i, j;
- 
-   /* If nonzero, the user gave us the `-p' or `-pg' flag.  */
-@@ -237,6 +244,8 @@
+@@ -237,12 +237,6 @@
  
  	case OPT_static_libstdc__:
  	  library = library >= 0 ? 2 : library;
-+	  if (LIBSTDCXX_PTHREAD != NULL)
-+  		added += 1;
- #ifdef HAVE_LD_STATIC_DYNAMIC
- 	  /* Remove -static-libstdc++ from the command only if target supports
- 	     LD_STATIC_DYNAMIC.  When not supported, it is left in so that a
-@@ -306,7 +315,10 @@
- #ifndef ENABLE_SHARED_LIBGCC
-   shared_libgcc = 0;
- #endif
--
-+#ifdef LIBSTDCXX_CIRCULAR
-+  if (library > 0)
-+    added += 2;
-+#endif
-   /* Add one for shared_libgcc or extra static library.  */
-   num_args = (argc + added + need_math + need_experimental
- 	      + (std_module * 5)
-@@ -412,6 +424,12 @@
+-#ifdef HAVE_LD_STATIC_DYNAMIC
+-	  /* Remove -static-libstdc++ from the command only if target supports
+-	     LD_STATIC_DYNAMIC.  When not supported, it is left in so that a
+-	     back-end target can use outfile substitution.  */
+-	  args[i] |= SKIPOPT;
+-#endif
+ 	  break;
+ 
+ 	case OPT_stdlib_:
+@@ -412,6 +406,13 @@
    /* Add `-lstdc++' if we haven't already done so.  */
    if (library > 0)
      {
-+#ifdef LIBSTDCXX_CIRCULAR
-+	  generate_option (OPT_Wl_, "--start-group", 1, CL_DRIVER,
-+			   &new_decoded_options[j++]);
-+	  started = 1;
-+#endif
-+
++      /* AROS: force -static-libstdc++ for every C++ link so the static-cxx
++	 startup objects (STARTFILE_SPEC %{static-libstdc++:...}, incl.
++	 __cxa_pure_virtual) are pulled in.  g++spec runs only for C++, so C
++	 programs are never affected.  */
++      generate_option (OPT_static_libstdc__, NULL, 1, CL_DRIVER,
++		       &new_decoded_options[j]);
++      j++;
        if (need_experimental && which_library == USE_LIBSTDCXX)
  	{
  	  generate_option (OPT_l, "stdc++exp", 1, CL_DRIVER,
-@@ -455,6 +473,13 @@
+@@ -447,14 +448,10 @@
+ 			 CL_DRIVER, &new_decoded_options[j]);
+       added_libraries++;
+       j++;
+-      /* Add target-dependent static library, if necessary.  */
+-      if ((static_link || library > 1) && LIBSTDCXX_STATIC != NULL)
+-	{
+ 	  generate_option (OPT_l, LIBSTDCXX_STATIC, 1,
+ 			   CL_DRIVER, &new_decoded_options[j]);
  	  added_libraries++;
  	  j++;
- 	}
-+      if ((static_link || library > 1) && LIBSTDCXX_PTHREAD != NULL)
-+	{
-+	  generate_option (OPT_l, LIBSTDCXX_PTHREAD, 1,
-+			   CL_DRIVER, &new_decoded_options[j]);
-+	  added_libraries++;
-+	  j++;
-+	}
+-	}
  #ifdef HAVE_LD_STATIC_DYNAMIC
        if (library > 1 && !static_link)
  	{
-@@ -481,6 +506,13 @@
-   if (shared_libgcc && !static_link)
-     generate_option (OPT_shared_libgcc, NULL, 1, CL_DRIVER,
- 		     &new_decoded_options[j++]);
-+#ifdef LIBSTDCXX_CIRCULAR
-+  if (started)
-+  {
-+    generate_option (OPT_Wl_, "--end-group", 1, CL_DRIVER,
-+			   &new_decoded_options[j++]);
-+  }
-+#endif
- 
-   *in_decoded_options_count = j;
-   *in_decoded_options = new_decoded_options;
 diff -ruN gcc-16.1.0/gcc/ginclude/aros/types/null.h gcc-16.1.0.aros/gcc/ginclude/aros/types/null.h
 --- gcc-16.1.0/gcc/ginclude/aros/types/null.h	1970-01-01 00:00:00.000000000 +0000
 +++ gcc-16.1.0.aros/gcc/ginclude/aros/types/null.h	2020-12-27 16:58:14.310000000 +0000

--- a/tools/crosstools/gnu/mmakefile.src
+++ b/tools/crosstools/gnu/mmakefile.src
@@ -352,5 +352,15 @@ LIBATOMIC_SRCDIR := $(HOSTDIR)/Ports/host/gcc/gcc-$(GCC_VERSION)/libatomic
 ifeq ($(AROS_TARGET_CPU),m68k)
 ISA_FLAGS:=$(ISA_FLOAT_FLAGS)
 endif
+# libatomic's all-local rule installs libatomic.la into $(gcc_objdir) = ../../gcc
+# (relative to its build dir) as an RPATH workaround, then removes it again.  In a
+# per-target build (core-*) the compiler is reused from the external toolchain and
+# is NOT rebuilt here, so that sibling gcc/ build dir is absent and the install
+# step fails.  Create it first so the workaround install succeeds.
+#MM
+tools-crosstools-gcc-libatomic-gccobjdir :
+	%mkdirs_q $(HOSTGENDIR)/$(CURDIR)/gcc/gcc
+
 %build_with_configure mmake=tools-crosstools-gcc-libatomic srcdir="$(LIBATOMIC_SRCDIR)" \
-	basedir= gendir="$(LIBATOMIC_OBJDIR)" extraoptions="$(LIBATOMIC_OPTS)" install_env="$(LIBATOMIC_ENV)"
+	basedir= gendir="$(LIBATOMIC_OBJDIR)" extraoptions="$(LIBATOMIC_OPTS)" install_env="$(LIBATOMIC_ENV)" \
+	postconfigure="tools-crosstools-gcc-libatomic-gccobjdir"


### PR DESCRIPTION
Three fixes to get a clean `core-linux-x86_64-d` (debug) build with the exp-gcc-16 toolchain (verified: Ubuntu 24.04, host gcc 13.3.0, `-j3`). Each is a separate commit.

### 1. libatomic install dir (crosstools mmakefile)
libatomic's `all-local` copies `libatomic.la` into `$(gcc_objdir)` = `../../gcc` (an RPATH workaround, then `rm`s it). In a per-target (`core-*`) build the compiler is reused from the external toolchain and is **not** rebuilt, so that sibling `gcc/` build dir is absent and the install step fails with `install: cannot create '.../gcc/libatomic.la': No such file`. Add a `#MM` metatarget that `%mkdirs_q` the dir, wired via `postconfigure=` on libatomic's `%build_with_configure`.

### 2. `-noclibs` Driver option (`gcc-16.1.0-aros.diff`, `gcc/config/aros.opt`)
`LIB_SPEC` uses `%{!noclibs:...}` but `aros.opt` never declared `noclibs` (it's present in the gcc-10.5 `aros.opt`; dropped since 13.4), so `xgcc` rejects the flag the AROS build passes when linking e.g. `stdlib.library`. Restore the `noclibs\nDriver` declaration.

### 3. Static C++ runtime (`gcc-16.1.0-aros.diff`, `gcc/cp/g++spec.cc`)
AROS links libstdc++ statically, so C++ programs need both `-lpthread` and the static-cxx startup objects (`static-cxx-ops` / `static-cxx-personality` / `static-cxx-cxa-pure-virtual`, the last of which provides `__cxa_pure_virtual`). 10.5 does this; the 16.1 port lost the behaviour. Three `g++spec.cc` changes — that file is the C++-only driver, so **C programs are never affected**:

- Drop upstream's guard on the `LIBSTDCXX_STATIC` add (matches 10.5) so `LIBSTDCXX_STATIC` (= `"pthread"` in `aros.h`) is linked for every C++ program.
- Inject `-static-libstdc++` for every C++ link, so `STARTFILE_SPEC`'s `%{static-libstdc++:...}` pulls the static-cxx startup objects.
- Remove the new-in-16.1 `SKIPOPT` that stripped `-static-libstdc++` before spec expansion under `HAVE_LD_STATIC_DYNAMIC` — this is why `STARTFILE_SPEC` never fired even when the flag was passed.

### Verification
On a fresh toolchain build:
- `x86_64-aros-g++ hello.cpp` and `x86_64-aros-g++ hello_exc.cpp` (exceptions/RTTI) link out of the box;
- a C program links with no pthread/static-cxx objects pulled in;
- the real `developer/debug/test/cplusplus` `cunit-cplusplus-static` / `cunit-cplusplus-exception` targets link clean — **no mmakefile changes, no collect-aros changes**.
