### PR TITLE
crosstools: gcc 16.1.0 - fix C++ exception handling (uninitialized DWARF reg-size table)

### DIFF
--- a/tools/crosstools/gnu/gcc-16.1.0-aros.diff
+++ b/tools/crosstools/gnu/gcc-16.1.0-aros.diff
@@ -1671,19 +1671,6 @@ diff -ruN gcc-16.1.0/libgcc/gthr.h gcc-16.1.0.aros/libgcc/gthr.h
  #ifndef GTHREAD_USE_WEAK
  #define GTHREAD_USE_WEAK 1
  #endif
-diff -ruN gcc-16.1.0/libgcc/unwind-dw2.c gcc-16.1.0.aros/libgcc/unwind-dw2.c
---- gcc-16.1.0/libgcc/unwind-dw2.c	2026-04-30 08:33:28.000000000 +0000
-+++ gcc-16.1.0.aros/libgcc/unwind-dw2.c	2020-12-27 16:58:14.310000000 +0000
-@@ -1322,7 +1322,9 @@
- static inline void
- init_dwarf_reg_size_table (void)
- {
-+#ifdef MD_FALLBACK_FRAME_STATE_FOR
-   __builtin_init_dwarf_reg_size_table (dwarf_reg_size_table);
-+#endif
- }
- 
- static void __attribute__((noinline))
 diff -ruN gcc-16.1.0/libgcc/unwind-dw2-fde.c gcc-16.1.0.aros/libgcc/unwind-dw2-fde.c
 --- gcc-16.1.0/libgcc/unwind-dw2-fde.c	2026-04-30 08:33:28.000000000 +0000
 +++ gcc-16.1.0.aros/libgcc/unwind-dw2-fde.c	2020-12-27 16:58:14.310000000 +0000

--- a/workbench/libs/commodities/mmakefile.src
+++ b/workbench/libs/commodities/mmakefile.src
@@ -1,6 +1,13 @@
 
 include $(SRCDIR)/config/aros.cfg
 
+# GCC 14+ makes -Wincompatible-pointer-types a hard error by default (was a
+# warning under gcc-10.5); invertkeymap.c passes struct timeval32* to
+# GetSysTime()'s struct timeval* parameter.  Restore the historical
+# warn-not-error behaviour rather than touching the call site.
+NOWARN_CFLAGS := $(NOWARN_INCOMPAT_POINTER_TYPES)
+TARGET_ISA_CFLAGS := $(NOWARN_CFLAGS)
+
 USER_LDFLAGS :=
 
 FILES := commodities_inputhandler eventfuncs

--- a/workbench/network/smbfs/source_code/mmakefile.src
+++ b/workbench/network/smbfs/source_code/mmakefile.src
@@ -3,6 +3,13 @@
 
 include $(SRCDIR)/config/aros.cfg
 
+# GCC 14+ makes -Wincompatible-pointer-types a hard error by default (was a
+# warning under gcc-10.5); main.c passes struct timeval32* to GetSysTime()'s
+# struct timeval* parameter (ie_TimeStamp is deliberately the ABI-stable
+# 32-bit timeval32).  Restore the historical warn-not-error behaviour.
+NOWARN_CFLAGS := $(NOWARN_INCOMPAT_POINTER_TYPES)
+TARGET_ISA_CFLAGS := $(NOWARN_CFLAGS)
+
 FILES = \
     main \
     proc \


### PR DESCRIPTION
The 16.1 port patched `libgcc/unwind-dw2.c` to wrap the call to
`__builtin_init_dwarf_reg_size_table(dwarf_reg_size_table)` in
`#ifdef MD_FALLBACK_FRAME_STATE_FOR`. AROS `#undef`s
`MD_FALLBACK_FRAME_STATE_FOR` (it has no OS signal frames), so on AROS
`init_dwarf_reg_size_table()` became a no-op and `dwarf_reg_size_table`
was left zero-filled.

The register-size table is unrelated to signal-frame fallback: it is
consumed by the DWARF unwinder when restoring registers. With it left at
zero, exception phase 1 (handler search, which does not need the table)
succeeds, but phase 2 (installing the handler - restoring registers / CFA
via `uw_install_context`) computes wrong sizes and
`_Unwind_RaiseException_Phase2` aborts. Net effect: every C++ throw that
reaches a handler crashes. This was invisible until C++ exception programs
became linkable on the 16.1 port.

Drop the bogus guard so the table is always initialised (matching
upstream). The two `#undef MD_FALLBACK_FRAME_STATE_FOR` config hunks are
legitimate and kept.

**Verified** on the hosted `linux-x86_64` `--enable-debug` build (rebuilt
against a fresh toolchain): `scripts/runtests.sh` is fully green - 419/419
tests, 0 failures / 0 errors, and `cunit/cplusplus/cunit-cplusplus-exception`
(the only failing suite before) now passes. Throw/catch across frames runs
destructors during unwinding, catches polymorphic exceptions by base
reference, and supports rethrow.
