### PR TITLE
fix crash when dragging mouse outside window during link click

### DIFF
--- a/workbench/classes/datatypes/text/agextension.c
+++ b/workbench/classes/datatypes/text/agextension.c
@@ -331,7 +331,7 @@ int HandleMouseLink(struct Text_Data *td, struct RastPort *rp, LONG x, LONG y, L
 	} else
 	{
 	    struct Line *line = NewFindLine(td, x, y, &xcur, NULL);
-	    if (line->ln_Flags & LNF_LINK)
+	    if (line && line->ln_Flags & LNF_LINK)
 	    {
 		if (td->marked_line != NULL && line != td->marked_line)
 		{


### PR DESCRIPTION
NewFindLine() can return NULL when the cursor is moved outside the window bounds. HandleMouseLink() was missing a NULL check on the return value in the else-if branch (line 333), causing a bus fault when dereferencing line->ln_Flags. Add the same NULL guard already present in the SELECTDOWN branch.