### PR TITLE
crosstools: gcc 16.1.0 - reserve r12 (library base) via FIXED_REGISTERS

### DIFF
--- a/tools/crosstools/gnu/gcc-16.1.0-aros.diff
+++ b/tools/crosstools/gnu/gcc-16.1.0-aros.diff
@@ -666,7 +666,7 @@ diff -ruN gcc-16.1.0/gcc/config/aros-stdint.h gcc-16.1.0.aros/gcc/config/aros-st
 diff -ruN gcc-16.1.0/gcc/config/i386/aros64.h gcc-16.1.0.aros/gcc/config/i386/aros64.h
 --- gcc-16.1.0/gcc/config/i386/aros64.h	1970-01-01 00:00:00.000000000 +0000
 +++ gcc-16.1.0.aros/gcc/config/i386/aros64.h	2020-12-27 16:58:14.310000000 +0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,68 @@
 +/* Definitions for AMD x86_64 running AROS systems with ELF64 format.
 +   Copyright (C) 1994, 1995, 1996, 1997, 1998, 1999, 2001, 2002
 +   Free Software Foundation, Inc.
@@ -699,6 +699,40 @@ diff -ruN gcc-16.1.0/gcc/config/i386/aros64.h gcc-16.1.0.aros/gcc/config/i386/ar
 +
 +#undef	LINK_SPEC
 +#define LINK_SPEC "%{!m32:-m elf_x86_64} %{m32:-m elf_i386} -L %R/lib" 
++
++/* Use the UNIX defaults, and add mno-red-zone.
++   In AROS, the stack pointer must be reliable at all times. */
++
++#undef TARGET_SUBTARGET_DEFAULT
++#define TARGET_SUBTARGET_DEFAULT \
++	(MASK_80387 | MASK_IEEE_FP | MASK_FLOAT_RETURNS | MASK_NO_RED_ZONE)
++
++/* r12 is reserved for library base pointer */
++
++#undef FIXED_REGISTERS
++#define FIXED_REGISTERS						\
++/*ax,dx,cx,bx,si,di,bp,sp,st,st1,st2,st3,st4,st5,st6,st7*/	\
++{  0, 0, 0, 0, 0, 0, 0, 1, 0,  0,  0,  0,  0,  0,  0,  0,	\
++/*arg,flags,fpsr,frame*/					\
++    1,    1,   1,    1,						\
++/*xmm0,xmm1,xmm2,xmm3,xmm4,xmm5,xmm6,xmm7*/			\
++     0,   0,   0,   0,   0,   0,   0,   0,			\
++/* mm0, mm1, mm2, mm3, mm4, mm5, mm6, mm7*/			\
++     0,   0,   0,   0,   0,   0,   0,   0,			\
++/*  r8,  r9, r10, r11, r12, r13, r14, r15*/			\
++     0,   0,   0,   0,   1,   0,   0,   0,			\
++/*xmm8,xmm9,xmm10,xmm11,xmm12,xmm13,xmm14,xmm15*/		\
++     0,   0,    0,    0,    0,    0,    0,    0,		\
++/*xmm16,xmm17,xmm18,xmm19,xmm20,xmm21,xmm22,xmm23*/		\
++     0,   0,    0,    0,    0,    0,    0,    0,		\
++/*xmm24,xmm25,xmm26,xmm27,xmm28,xmm29,xmm30,xmm31*/		\
++     0,   0,    0,    0,    0,    0,    0,    0,		\
++/*  k0,  k1, k2, k3, k4, k5, k6, k7*/				\
++     0,  0,   0,  0,  0,  0,  0,  0,				\
++/*  r16,  r17, r18, r19, r20, r21, r22, r23*/			\
++     0,   0,   0,   0,   0,   0,   0,   0,			\
++/*  r24,  r25, r26, r27, r28, r29, r30, r31*/			\
++     0,   0,   0,   0,   0,   0,   0,   0}
 +
 +/* FIXME: AROS doesn't support dw2 unwinding yet.  */
 diff -ruN gcc-16.1.0/gcc/config/i386/aros.h gcc-16.1.0.aros/gcc/config/i386/aros.h


### PR DESCRIPTION
Reserves **r12 (the AROS x86-64 library base register) via `FIXED_REGISTERS`** in the gcc-16.1.0 `aros64.h` hunk of `gcc-16.1.0-aros.diff`.

### Why
The gcc-16 `aros64.h` was a stub that omitted `FIXED_REGISTERS`, so r12 was only reserved by the `-ffixed-r12` command-line flag. That flag alone is **not** enough: at `-O2` the register allocator still treats r12 as callee-saved and mis-schedules the base save/restore around cross-library LVO calls, restoring the *old* r12 **before** the `call` — so the callee runs with a corrupted library base.

### Observed
`core-pc-x86_64` (`-O2` release) booted to Wanderer then Guru'd `0x80000003` in the **PoPo** task:
`muimaster` → `coolimages` `InitCoolButtonClass` → `MakeClass` → the corrupted base led to `ObtainSemaphoreShared` on an uninitialized semaphore (`AN_SemCorrupt`). The hosted `-O0` build was unaffected because `-O0` schedules the restore *after* the call.

### Fix
Add `FIXED_REGISTERS` (r12=1) in gcc-16's own register layout (it adds the APX `r16-r31` rows, so gcc-10.5's array can't be pasted verbatim), plus `TARGET_SUBTARGET_DEFAULT` (`MASK_NO_RED_ZONE`) for parity — matching gcc-10.5's `aros64.h`.

### Verified
- `-O2` codegen keeps r12 = base across the `MakeClass` call (no pre-call restore).
- **`core-pc-x86_64` now boots to the Wanderer desktop** (installer runs, `ahci.device 0` detected).
- `-O2` hosted `core-linux-x86_64` build runs cleanly (no `AN_SemCorrupt`).

### Note for maintainer
The upstream r12 work on `exp-gcc-16` (`a7a8746ca4` "make gcc always consider x86-64 register r12 as fixed... regcall macros do the procedure calls in C again") lands in the **gcc-10.5** diff + `gencall.c`; the **gcc-16** diff's `aros64.h` still lacked the reservation, which this brings to parity (aligns with your earlier PR #174). If you'd rather the gcc-16 port follow the newer `gencall`/regcall approach instead of `FIXED_REGISTERS`-in-header, happy to redo it that way.
