### PR TITLE
Fix OpenGL window resize scaling when minimizing

### DIFF
--- a/workbench/libs/mesa/mesa3dgl_glaswapbuffers.c
+++ b/workbench/libs/mesa/mesa3dgl_glaswapbuffers.c
@@ -51,6 +51,8 @@
 
     D(bug("[MESA3DGL] %s()\n", __func__));
 
+    MESA3DGLCheckAndUpdateBufferSize(_ctx);
+
     if (_ctx->framebuffer->render_resource)
     {
         /* Flush rendering cache before blitting */
@@ -60,6 +62,4 @@
             _ctx->visible_rp, _ctx->left, _ctx->top,
             _ctx->framebuffer->width, _ctx->framebuffer->height);
     }
-
-    MESA3DGLCheckAndUpdateBufferSize(_ctx);
 }


### PR DESCRIPTION
When shrinking a game window using OpenGL, the rendered image was drawn on the window frame because buffer size update (MESA3DGLCheckAndUpdateBufferSize) was called AFTER BltPipeResourceRastPort, causing the blit to use old (larger) framebuffer dimensions.

Moved MESA3DGLCheckAndUpdateBufferSize call to execute BEFORE the blit operation so the buffer dimensions are updated with the correct (new) size before rendering to screen.